### PR TITLE
Python3 compatibility.

### DIFF
--- a/freetype/__init__.py
+++ b/freetype/__init__.py
@@ -1160,7 +1160,7 @@ class Face( object ):
           correspond to the internal indices used within the file. This is done
           to ensure that value 0 always corresponds to the 'missing glyph'.
         '''
-        if type( charcode ) in (str,unicode):
+        if type( charcode ) is str:
             charcode = ord( charcode )
         return FT_Get_Char_Index( self._FT_Face, charcode )
 


### PR DESCRIPTION
This fixes the exception:
File "/usr/local/lib/python3.3/dist-packages/freetype/**init**.py", line 1163, in get_char_index
    if type( charcode ) in (str,unicode):
NameError: global name 'unicode' is not defined
