### PR TITLE
Encode filename to filesystem encoding

### DIFF
--- a/freetype/__init__.py
+++ b/freetype/__init__.py
@@ -1045,7 +1045,7 @@ class Face( object ):
         face = FT_Face( )
         self._FT_Face = None
         #error = FT_New_Face( library, filename, 0, byref(face) )
-        u_filename = c_char_p(filename.encode())
+        u_filename = c_char_p(filename.encode(sys.getfilesystemencoding()))
         error = FT_New_Face( library, u_filename, index, byref(face) )
         if error: raise FT_Exception( error )
         self._filename = filename
@@ -1080,7 +1080,8 @@ class Face( object ):
         attachments.
         '''
 
-        error = FT_Attach_File( self._FT_Face, filename)
+        u_filename = c_char_p(filename.encode(sys.getfilesystemencoding()))
+        error = FT_Attach_File( self._FT_Face, u_filename)
         if error: raise FT_Exception( error)
 
 


### PR DESCRIPTION
This fix some "cannot open resource" in environment which filesystem encoding is different from default encoding (for example Windows, some Unix).

And, should we fallback to `FT_New_Memory_Face` when encode failed?
