### PR TITLE
Windows: fall back to current working directory if freetype library not found elsewhere.

### DIFF
--- a/freetype/__init__.py
+++ b/freetype/__init__.py
@@ -58,7 +58,7 @@ if not _dllFound:
     raise RuntimeError('Freetype library not found')
 
 __dll__ = dll
-FT_library_filename = libName
+FT_Library_filename = libName
 
 # -----------------------------------------------------------------------------
 # High-level API of FreeType 2


### PR DESCRIPTION
Rework the library loading code to allow the freetype dll to be loaded from the current working directory.
Without this for me this binding is useless.

And unless i am completely missing something that comment at the top is wrong about FT_library_filename. Once a value set as a global on one module will not propagate to the other. Even if that were the case the value would get overwritten before its ever checked.
