### PR TITLE
Split the ctypes function binding out into raw.py.

### DIFF
--- a/freetype/__init__.py
+++ b/freetype/__init__.py
@@ -16,54 +16,23 @@ Note: C Library will be searched using the ctypes.util.find_library. However,
       this search might fail. In such a case (or for other reasons), you may
       have to specify an explicit path below.
 '''
-import os
 import sys
-import platform
 from ctypes import *
-from freetype.ft_types import *
-from freetype.ft_enums import *
-from freetype.ft_errors import *
-from freetype.ft_structs import *
-import ctypes.util
+
+from freetype.raw import *
 
 # Hack to get unicode class in python3
 PY3 = sys.version_info[0] == 3
 if PY3: unicode = str
 
-
-__dll__    = None
 __handle__ = None
 
-# on windows all ctypes does when checking for the library
-# is to append .dll to the end and look for an exact match
-# within any entry in PATH.
-filename = ctypes.util.find_library('freetype')
 
-if filename is None:
-    if platform.system() == 'Windows':
-        # Check current working directory for dll as ctypes fails to do so
-        filename = os.path.join(os.path.realpath('.'), 'freetype.dll')
-    else:
-        filename = 'libfreetype.so.6'
-
-try:
-    dll = ctypes.CDLL(filename)
-    _found = True
-except (OSError, TypeError):
-    _found = False
-
-if not _found:
-    raise RuntimeError('Freetype library not found')
-
-__dll__ = dll
 FT_Library_filename = filename
 
 # -----------------------------------------------------------------------------
 # High-level API of FreeType 2
 # -----------------------------------------------------------------------------
-FT_Init_FreeType       = __dll__.FT_Init_FreeType
-FT_Done_FreeType       = __dll__.FT_Done_FreeType
-FT_Library_Version     = __dll__.FT_Library_Version
 
 def __del_library__(self):
     global __handle__
@@ -99,88 +68,10 @@ def version():
     amajor = FT_Int()
     aminor = FT_Int()
     apatch = FT_Int()
+    
     library = get_handle()
     FT_Library_Version(library, byref(amajor), byref(aminor), byref(apatch))
     return (amajor.value, aminor.value, apatch.value)
-
-
-try:
-    FT_Library_SetLcdFilter= __dll__.FT_Library_SetLcdFilter
-except:
-    def FT_Library_SetLcdFilter (*args, **kwargs):
-        return 0
-if version()>=(2,4,0):
-    FT_Library_SetLcdFilterWeights = __dll__.FT_Library_SetLcdFilterWeights
-FT_New_Face            = __dll__.FT_New_Face
-FT_New_Memory_Face     = __dll__.FT_New_Memory_Face
-FT_Open_Face           = __dll__.FT_Open_Face
-FT_Attach_File         = __dll__.FT_Attach_File
-FT_Attach_Stream       = __dll__.FT_Attach_Stream
-if version()>=(2,4,2):
-    FT_Reference_Face      = __dll__.FT_Reference_Face
-FT_Done_Face           = __dll__.FT_Done_Face
-FT_Done_Glyph          = __dll__.FT_Done_Glyph
-FT_Select_Size         = __dll__.FT_Select_Size
-FT_Request_Size        = __dll__.FT_Request_Size
-FT_Set_Char_Size       = __dll__.FT_Set_Char_Size
-FT_Set_Pixel_Sizes     = __dll__.FT_Set_Pixel_Sizes
-FT_Load_Glyph          = __dll__.FT_Load_Glyph
-FT_Load_Char           = __dll__.FT_Load_Char
-FT_Set_Transform       = __dll__.FT_Set_Transform
-FT_Render_Glyph        = __dll__.FT_Render_Glyph
-FT_Get_Kerning         = __dll__.FT_Get_Kerning
-FT_Get_Track_Kerning   = __dll__.FT_Get_Track_Kerning
-FT_Get_Glyph_Name      = __dll__.FT_Get_Glyph_Name
-FT_Get_Glyph           = __dll__.FT_Get_Glyph
-
-FT_Glyph_Get_CBox      = __dll__.FT_Glyph_Get_CBox
-
-FT_Get_Postscript_Name = __dll__.FT_Get_Postscript_Name
-FT_Get_Postscript_Name.restype = c_char_p
-FT_Select_Charmap      = __dll__.FT_Select_Charmap
-FT_Set_Charmap         = __dll__.FT_Set_Charmap
-FT_Get_Charmap_Index   = __dll__.FT_Get_Charmap_Index
-FT_Get_CMap_Language_ID= __dll__.FT_Get_CMap_Language_ID
-FT_Get_CMap_Format     = __dll__.FT_Get_CMap_Format
-FT_Get_Char_Index      = __dll__.FT_Get_Char_Index
-FT_Get_First_Char      = __dll__.FT_Get_First_Char
-FT_Get_Next_Char       = __dll__.FT_Get_Next_Char
-FT_Get_Name_Index      = __dll__.FT_Get_Name_Index
-FT_Get_SubGlyph_Info   = __dll__.FT_Get_SubGlyph_Info
-if version()>=(2,3,8):
-    FT_Get_FSType_Flags    = __dll__.FT_Get_FSType_Flags
-    FT_Get_FSType_Flags.restype  = c_ushort
-
-FT_Get_X11_Font_Format = __dll__.FT_Get_X11_Font_Format
-FT_Get_X11_Font_Format.restype = c_char_p
-
-FT_Get_Sfnt_Name_Count = __dll__.FT_Get_Sfnt_Name_Count
-FT_Get_Sfnt_Name       = __dll__.FT_Get_Sfnt_Name
-FT_Get_Advance         = __dll__.FT_Get_Advance
-
-
-FT_Outline_GetInsideBorder  = __dll__.FT_Outline_GetInsideBorder
-FT_Outline_GetOutsideBorder = __dll__.FT_Outline_GetOutsideBorder
-FT_Outline_Get_BBox         = __dll__.FT_Outline_Get_BBox
-FT_Outline_Get_CBox         = __dll__.FT_Outline_Get_CBox
-FT_Stroker_New              = __dll__.FT_Stroker_New
-FT_Stroker_Set              = __dll__.FT_Stroker_Set
-FT_Stroker_Rewind           = __dll__.FT_Stroker_Rewind
-FT_Stroker_ParseOutline     = __dll__.FT_Stroker_ParseOutline
-FT_Stroker_BeginSubPath     = __dll__.FT_Stroker_BeginSubPath
-FT_Stroker_EndSubPath       = __dll__.FT_Stroker_EndSubPath
-FT_Stroker_LineTo           = __dll__.FT_Stroker_LineTo
-FT_Stroker_ConicTo          = __dll__.FT_Stroker_ConicTo
-FT_Stroker_CubicTo          = __dll__.FT_Stroker_CubicTo
-FT_Stroker_GetBorderCounts  = __dll__.FT_Stroker_GetBorderCounts
-FT_Stroker_ExportBorder     = __dll__.FT_Stroker_ExportBorder
-FT_Stroker_GetCounts        = __dll__.FT_Stroker_GetCounts
-FT_Stroker_Export           = __dll__.FT_Stroker_Export
-FT_Stroker_Done             = __dll__.FT_Stroker_Done
-FT_Glyph_Stroke             = __dll__.FT_Glyph_Stroke
-FT_Glyph_StrokeBorder       = __dll__.FT_Glyph_StrokeBorder
-FT_Glyph_To_Bitmap          = __dll__.FT_Glyph_To_Bitmap
-
 
 
 # -----------------------------------------------------------------------------

--- a/freetype/raw.py
+++ b/freetype/raw.py
@@ -20,8 +20,6 @@ from freetype.ft_enums import *
 from freetype.ft_errors import *
 from freetype.ft_structs import *
 
-__dll__    = None
-
 # on windows all ctypes does when checking for the library
 # is to append .dll to the end and look for an exact match
 # within any entry in PATH.
@@ -35,103 +33,98 @@ if filename is None:
         filename = 'libfreetype.so.6'
 
 try:
-    dll = ctypes.CDLL(filename)
-    _found = True
+    _dll = ctypes.CDLL(filename)
 except (OSError, TypeError):
-    _found = False
-
-if not _found:
+    _dll = None
     raise RuntimeError('Freetype library not found')
 
-__dll__ = dll
-
-FT_Init_FreeType       = __dll__.FT_Init_FreeType
-FT_Done_FreeType       = __dll__.FT_Done_FreeType
-FT_Library_Version     = __dll__.FT_Library_Version
+FT_Init_FreeType       = _dll.FT_Init_FreeType
+FT_Done_FreeType       = _dll.FT_Done_FreeType
+FT_Library_Version     = _dll.FT_Library_Version
 
 try:
-    FT_Library_SetLcdFilter= __dll__.FT_Library_SetLcdFilter
+    FT_Library_SetLcdFilter= _dll.FT_Library_SetLcdFilter
 except AttributeError:
     def FT_Library_SetLcdFilter (*args, **kwargs):
         return 0
 try:
-    FT_Library_SetLcdFilterWeights = __dll__.FT_Library_SetLcdFilterWeights
+    FT_Library_SetLcdFilterWeights = _dll.FT_Library_SetLcdFilterWeights
 except AttributeError:
     pass
 
-FT_New_Face            = __dll__.FT_New_Face
-FT_New_Memory_Face     = __dll__.FT_New_Memory_Face
-FT_Open_Face           = __dll__.FT_Open_Face
-FT_Attach_File         = __dll__.FT_Attach_File
-FT_Attach_Stream       = __dll__.FT_Attach_Stream
+FT_New_Face            = _dll.FT_New_Face
+FT_New_Memory_Face     = _dll.FT_New_Memory_Face
+FT_Open_Face           = _dll.FT_Open_Face
+FT_Attach_File         = _dll.FT_Attach_File
+FT_Attach_Stream       = _dll.FT_Attach_Stream
 
 try:
-    FT_Reference_Face      = __dll__.FT_Reference_Face
+    FT_Reference_Face      = _dll.FT_Reference_Face
 except AttributeError:
 	pass
 
-FT_Done_Face           = __dll__.FT_Done_Face
-FT_Done_Glyph          = __dll__.FT_Done_Glyph
-FT_Select_Size         = __dll__.FT_Select_Size
-FT_Request_Size        = __dll__.FT_Request_Size
-FT_Set_Char_Size       = __dll__.FT_Set_Char_Size
-FT_Set_Pixel_Sizes     = __dll__.FT_Set_Pixel_Sizes
-FT_Load_Glyph          = __dll__.FT_Load_Glyph
-FT_Load_Char           = __dll__.FT_Load_Char
-FT_Set_Transform       = __dll__.FT_Set_Transform
-FT_Render_Glyph        = __dll__.FT_Render_Glyph
-FT_Get_Kerning         = __dll__.FT_Get_Kerning
-FT_Get_Track_Kerning   = __dll__.FT_Get_Track_Kerning
-FT_Get_Glyph_Name      = __dll__.FT_Get_Glyph_Name
-FT_Get_Glyph           = __dll__.FT_Get_Glyph
+FT_Done_Face           = _dll.FT_Done_Face
+FT_Done_Glyph          = _dll.FT_Done_Glyph
+FT_Select_Size         = _dll.FT_Select_Size
+FT_Request_Size        = _dll.FT_Request_Size
+FT_Set_Char_Size       = _dll.FT_Set_Char_Size
+FT_Set_Pixel_Sizes     = _dll.FT_Set_Pixel_Sizes
+FT_Load_Glyph          = _dll.FT_Load_Glyph
+FT_Load_Char           = _dll.FT_Load_Char
+FT_Set_Transform       = _dll.FT_Set_Transform
+FT_Render_Glyph        = _dll.FT_Render_Glyph
+FT_Get_Kerning         = _dll.FT_Get_Kerning
+FT_Get_Track_Kerning   = _dll.FT_Get_Track_Kerning
+FT_Get_Glyph_Name      = _dll.FT_Get_Glyph_Name
+FT_Get_Glyph           = _dll.FT_Get_Glyph
 
-FT_Glyph_Get_CBox      = __dll__.FT_Glyph_Get_CBox
+FT_Glyph_Get_CBox      = _dll.FT_Glyph_Get_CBox
 
-FT_Get_Postscript_Name = __dll__.FT_Get_Postscript_Name
+FT_Get_Postscript_Name = _dll.FT_Get_Postscript_Name
 FT_Get_Postscript_Name.restype = c_char_p
-FT_Select_Charmap      = __dll__.FT_Select_Charmap
-FT_Set_Charmap         = __dll__.FT_Set_Charmap
-FT_Get_Charmap_Index   = __dll__.FT_Get_Charmap_Index
-FT_Get_CMap_Language_ID= __dll__.FT_Get_CMap_Language_ID
-FT_Get_CMap_Format     = __dll__.FT_Get_CMap_Format
-FT_Get_Char_Index      = __dll__.FT_Get_Char_Index
-FT_Get_First_Char      = __dll__.FT_Get_First_Char
-FT_Get_Next_Char       = __dll__.FT_Get_Next_Char
-FT_Get_Name_Index      = __dll__.FT_Get_Name_Index
-FT_Get_SubGlyph_Info   = __dll__.FT_Get_SubGlyph_Info
+FT_Select_Charmap      = _dll.FT_Select_Charmap
+FT_Set_Charmap         = _dll.FT_Set_Charmap
+FT_Get_Charmap_Index   = _dll.FT_Get_Charmap_Index
+FT_Get_CMap_Language_ID= _dll.FT_Get_CMap_Language_ID
+FT_Get_CMap_Format     = _dll.FT_Get_CMap_Format
+FT_Get_Char_Index      = _dll.FT_Get_Char_Index
+FT_Get_First_Char      = _dll.FT_Get_First_Char
+FT_Get_Next_Char       = _dll.FT_Get_Next_Char
+FT_Get_Name_Index      = _dll.FT_Get_Name_Index
+FT_Get_SubGlyph_Info   = _dll.FT_Get_SubGlyph_Info
 
 try:
-    FT_Get_FSType_Flags    = __dll__.FT_Get_FSType_Flags
+    FT_Get_FSType_Flags    = _dll.FT_Get_FSType_Flags
     FT_Get_FSType_Flags.restype  = c_ushort
 except AttributeError:
 	pass
 
-FT_Get_X11_Font_Format = __dll__.FT_Get_X11_Font_Format
+FT_Get_X11_Font_Format = _dll.FT_Get_X11_Font_Format
 FT_Get_X11_Font_Format.restype = c_char_p
 
-FT_Get_Sfnt_Name_Count = __dll__.FT_Get_Sfnt_Name_Count
-FT_Get_Sfnt_Name       = __dll__.FT_Get_Sfnt_Name
-FT_Get_Advance         = __dll__.FT_Get_Advance
+FT_Get_Sfnt_Name_Count = _dll.FT_Get_Sfnt_Name_Count
+FT_Get_Sfnt_Name       = _dll.FT_Get_Sfnt_Name
+FT_Get_Advance         = _dll.FT_Get_Advance
 
 
-FT_Outline_GetInsideBorder  = __dll__.FT_Outline_GetInsideBorder
-FT_Outline_GetOutsideBorder = __dll__.FT_Outline_GetOutsideBorder
-FT_Outline_Get_BBox         = __dll__.FT_Outline_Get_BBox
-FT_Outline_Get_CBox         = __dll__.FT_Outline_Get_CBox
-FT_Stroker_New              = __dll__.FT_Stroker_New
-FT_Stroker_Set              = __dll__.FT_Stroker_Set
-FT_Stroker_Rewind           = __dll__.FT_Stroker_Rewind
-FT_Stroker_ParseOutline     = __dll__.FT_Stroker_ParseOutline
-FT_Stroker_BeginSubPath     = __dll__.FT_Stroker_BeginSubPath
-FT_Stroker_EndSubPath       = __dll__.FT_Stroker_EndSubPath
-FT_Stroker_LineTo           = __dll__.FT_Stroker_LineTo
-FT_Stroker_ConicTo          = __dll__.FT_Stroker_ConicTo
-FT_Stroker_CubicTo          = __dll__.FT_Stroker_CubicTo
-FT_Stroker_GetBorderCounts  = __dll__.FT_Stroker_GetBorderCounts
-FT_Stroker_ExportBorder     = __dll__.FT_Stroker_ExportBorder
-FT_Stroker_GetCounts        = __dll__.FT_Stroker_GetCounts
-FT_Stroker_Export           = __dll__.FT_Stroker_Export
-FT_Stroker_Done             = __dll__.FT_Stroker_Done
-FT_Glyph_Stroke             = __dll__.FT_Glyph_Stroke
-FT_Glyph_StrokeBorder       = __dll__.FT_Glyph_StrokeBorder
-FT_Glyph_To_Bitmap          = __dll__.FT_Glyph_To_Bitmap
+FT_Outline_GetInsideBorder  = _dll.FT_Outline_GetInsideBorder
+FT_Outline_GetOutsideBorder = _dll.FT_Outline_GetOutsideBorder
+FT_Outline_Get_BBox         = _dll.FT_Outline_Get_BBox
+FT_Outline_Get_CBox         = _dll.FT_Outline_Get_CBox
+FT_Stroker_New              = _dll.FT_Stroker_New
+FT_Stroker_Set              = _dll.FT_Stroker_Set
+FT_Stroker_Rewind           = _dll.FT_Stroker_Rewind
+FT_Stroker_ParseOutline     = _dll.FT_Stroker_ParseOutline
+FT_Stroker_BeginSubPath     = _dll.FT_Stroker_BeginSubPath
+FT_Stroker_EndSubPath       = _dll.FT_Stroker_EndSubPath
+FT_Stroker_LineTo           = _dll.FT_Stroker_LineTo
+FT_Stroker_ConicTo          = _dll.FT_Stroker_ConicTo
+FT_Stroker_CubicTo          = _dll.FT_Stroker_CubicTo
+FT_Stroker_GetBorderCounts  = _dll.FT_Stroker_GetBorderCounts
+FT_Stroker_ExportBorder     = _dll.FT_Stroker_ExportBorder
+FT_Stroker_GetCounts        = _dll.FT_Stroker_GetCounts
+FT_Stroker_Export           = _dll.FT_Stroker_Export
+FT_Stroker_Done             = _dll.FT_Stroker_Done
+FT_Glyph_Stroke             = _dll.FT_Glyph_Stroke
+FT_Glyph_StrokeBorder       = _dll.FT_Glyph_StrokeBorder
+FT_Glyph_To_Bitmap          = _dll.FT_Glyph_To_Bitmap

--- a/freetype/raw.py
+++ b/freetype/raw.py
@@ -33,98 +33,98 @@ if filename is None:
         filename = 'libfreetype.so.6'
 
 try:
-    _dll = ctypes.CDLL(filename)
+    _lib = ctypes.CDLL(filename)
 except (OSError, TypeError):
-    _dll = None
+    _lib = None
     raise RuntimeError('Freetype library not found')
 
-FT_Init_FreeType       = _dll.FT_Init_FreeType
-FT_Done_FreeType       = _dll.FT_Done_FreeType
-FT_Library_Version     = _dll.FT_Library_Version
+FT_Init_FreeType       = _lib.FT_Init_FreeType
+FT_Done_FreeType       = _lib.FT_Done_FreeType
+FT_Library_Version     = _lib.FT_Library_Version
 
 try:
-    FT_Library_SetLcdFilter= _dll.FT_Library_SetLcdFilter
+    FT_Library_SetLcdFilter= _lib.FT_Library_SetLcdFilter
 except AttributeError:
     def FT_Library_SetLcdFilter (*args, **kwargs):
         return 0
 try:
-    FT_Library_SetLcdFilterWeights = _dll.FT_Library_SetLcdFilterWeights
+    FT_Library_SetLcdFilterWeights = _lib.FT_Library_SetLcdFilterWeights
 except AttributeError:
     pass
 
-FT_New_Face            = _dll.FT_New_Face
-FT_New_Memory_Face     = _dll.FT_New_Memory_Face
-FT_Open_Face           = _dll.FT_Open_Face
-FT_Attach_File         = _dll.FT_Attach_File
-FT_Attach_Stream       = _dll.FT_Attach_Stream
+FT_New_Face            = _lib.FT_New_Face
+FT_New_Memory_Face     = _lib.FT_New_Memory_Face
+FT_Open_Face           = _lib.FT_Open_Face
+FT_Attach_File         = _lib.FT_Attach_File
+FT_Attach_Stream       = _lib.FT_Attach_Stream
 
 try:
-    FT_Reference_Face      = _dll.FT_Reference_Face
+    FT_Reference_Face      = _lib.FT_Reference_Face
 except AttributeError:
 	pass
 
-FT_Done_Face           = _dll.FT_Done_Face
-FT_Done_Glyph          = _dll.FT_Done_Glyph
-FT_Select_Size         = _dll.FT_Select_Size
-FT_Request_Size        = _dll.FT_Request_Size
-FT_Set_Char_Size       = _dll.FT_Set_Char_Size
-FT_Set_Pixel_Sizes     = _dll.FT_Set_Pixel_Sizes
-FT_Load_Glyph          = _dll.FT_Load_Glyph
-FT_Load_Char           = _dll.FT_Load_Char
-FT_Set_Transform       = _dll.FT_Set_Transform
-FT_Render_Glyph        = _dll.FT_Render_Glyph
-FT_Get_Kerning         = _dll.FT_Get_Kerning
-FT_Get_Track_Kerning   = _dll.FT_Get_Track_Kerning
-FT_Get_Glyph_Name      = _dll.FT_Get_Glyph_Name
-FT_Get_Glyph           = _dll.FT_Get_Glyph
+FT_Done_Face           = _lib.FT_Done_Face
+FT_Done_Glyph          = _lib.FT_Done_Glyph
+FT_Select_Size         = _lib.FT_Select_Size
+FT_Request_Size        = _lib.FT_Request_Size
+FT_Set_Char_Size       = _lib.FT_Set_Char_Size
+FT_Set_Pixel_Sizes     = _lib.FT_Set_Pixel_Sizes
+FT_Load_Glyph          = _lib.FT_Load_Glyph
+FT_Load_Char           = _lib.FT_Load_Char
+FT_Set_Transform       = _lib.FT_Set_Transform
+FT_Render_Glyph        = _lib.FT_Render_Glyph
+FT_Get_Kerning         = _lib.FT_Get_Kerning
+FT_Get_Track_Kerning   = _lib.FT_Get_Track_Kerning
+FT_Get_Glyph_Name      = _lib.FT_Get_Glyph_Name
+FT_Get_Glyph           = _lib.FT_Get_Glyph
 
-FT_Glyph_Get_CBox      = _dll.FT_Glyph_Get_CBox
+FT_Glyph_Get_CBox      = _lib.FT_Glyph_Get_CBox
 
-FT_Get_Postscript_Name = _dll.FT_Get_Postscript_Name
+FT_Get_Postscript_Name = _lib.FT_Get_Postscript_Name
 FT_Get_Postscript_Name.restype = c_char_p
-FT_Select_Charmap      = _dll.FT_Select_Charmap
-FT_Set_Charmap         = _dll.FT_Set_Charmap
-FT_Get_Charmap_Index   = _dll.FT_Get_Charmap_Index
-FT_Get_CMap_Language_ID= _dll.FT_Get_CMap_Language_ID
-FT_Get_CMap_Format     = _dll.FT_Get_CMap_Format
-FT_Get_Char_Index      = _dll.FT_Get_Char_Index
-FT_Get_First_Char      = _dll.FT_Get_First_Char
-FT_Get_Next_Char       = _dll.FT_Get_Next_Char
-FT_Get_Name_Index      = _dll.FT_Get_Name_Index
-FT_Get_SubGlyph_Info   = _dll.FT_Get_SubGlyph_Info
+FT_Select_Charmap      = _lib.FT_Select_Charmap
+FT_Set_Charmap         = _lib.FT_Set_Charmap
+FT_Get_Charmap_Index   = _lib.FT_Get_Charmap_Index
+FT_Get_CMap_Language_ID= _lib.FT_Get_CMap_Language_ID
+FT_Get_CMap_Format     = _lib.FT_Get_CMap_Format
+FT_Get_Char_Index      = _lib.FT_Get_Char_Index
+FT_Get_First_Char      = _lib.FT_Get_First_Char
+FT_Get_Next_Char       = _lib.FT_Get_Next_Char
+FT_Get_Name_Index      = _lib.FT_Get_Name_Index
+FT_Get_SubGlyph_Info   = _lib.FT_Get_SubGlyph_Info
 
 try:
-    FT_Get_FSType_Flags    = _dll.FT_Get_FSType_Flags
+    FT_Get_FSType_Flags    = _lib.FT_Get_FSType_Flags
     FT_Get_FSType_Flags.restype  = c_ushort
 except AttributeError:
 	pass
 
-FT_Get_X11_Font_Format = _dll.FT_Get_X11_Font_Format
+FT_Get_X11_Font_Format = _lib.FT_Get_X11_Font_Format
 FT_Get_X11_Font_Format.restype = c_char_p
 
-FT_Get_Sfnt_Name_Count = _dll.FT_Get_Sfnt_Name_Count
-FT_Get_Sfnt_Name       = _dll.FT_Get_Sfnt_Name
-FT_Get_Advance         = _dll.FT_Get_Advance
+FT_Get_Sfnt_Name_Count = _lib.FT_Get_Sfnt_Name_Count
+FT_Get_Sfnt_Name       = _lib.FT_Get_Sfnt_Name
+FT_Get_Advance         = _lib.FT_Get_Advance
 
 
-FT_Outline_GetInsideBorder  = _dll.FT_Outline_GetInsideBorder
-FT_Outline_GetOutsideBorder = _dll.FT_Outline_GetOutsideBorder
-FT_Outline_Get_BBox         = _dll.FT_Outline_Get_BBox
-FT_Outline_Get_CBox         = _dll.FT_Outline_Get_CBox
-FT_Stroker_New              = _dll.FT_Stroker_New
-FT_Stroker_Set              = _dll.FT_Stroker_Set
-FT_Stroker_Rewind           = _dll.FT_Stroker_Rewind
-FT_Stroker_ParseOutline     = _dll.FT_Stroker_ParseOutline
-FT_Stroker_BeginSubPath     = _dll.FT_Stroker_BeginSubPath
-FT_Stroker_EndSubPath       = _dll.FT_Stroker_EndSubPath
-FT_Stroker_LineTo           = _dll.FT_Stroker_LineTo
-FT_Stroker_ConicTo          = _dll.FT_Stroker_ConicTo
-FT_Stroker_CubicTo          = _dll.FT_Stroker_CubicTo
-FT_Stroker_GetBorderCounts  = _dll.FT_Stroker_GetBorderCounts
-FT_Stroker_ExportBorder     = _dll.FT_Stroker_ExportBorder
-FT_Stroker_GetCounts        = _dll.FT_Stroker_GetCounts
-FT_Stroker_Export           = _dll.FT_Stroker_Export
-FT_Stroker_Done             = _dll.FT_Stroker_Done
-FT_Glyph_Stroke             = _dll.FT_Glyph_Stroke
-FT_Glyph_StrokeBorder       = _dll.FT_Glyph_StrokeBorder
-FT_Glyph_To_Bitmap          = _dll.FT_Glyph_To_Bitmap
+FT_Outline_GetInsideBorder  = _lib.FT_Outline_GetInsideBorder
+FT_Outline_GetOutsideBorder = _lib.FT_Outline_GetOutsideBorder
+FT_Outline_Get_BBox         = _lib.FT_Outline_Get_BBox
+FT_Outline_Get_CBox         = _lib.FT_Outline_Get_CBox
+FT_Stroker_New              = _lib.FT_Stroker_New
+FT_Stroker_Set              = _lib.FT_Stroker_Set
+FT_Stroker_Rewind           = _lib.FT_Stroker_Rewind
+FT_Stroker_ParseOutline     = _lib.FT_Stroker_ParseOutline
+FT_Stroker_BeginSubPath     = _lib.FT_Stroker_BeginSubPath
+FT_Stroker_EndSubPath       = _lib.FT_Stroker_EndSubPath
+FT_Stroker_LineTo           = _lib.FT_Stroker_LineTo
+FT_Stroker_ConicTo          = _lib.FT_Stroker_ConicTo
+FT_Stroker_CubicTo          = _lib.FT_Stroker_CubicTo
+FT_Stroker_GetBorderCounts  = _lib.FT_Stroker_GetBorderCounts
+FT_Stroker_ExportBorder     = _lib.FT_Stroker_ExportBorder
+FT_Stroker_GetCounts        = _lib.FT_Stroker_GetCounts
+FT_Stroker_Export           = _lib.FT_Stroker_Export
+FT_Stroker_Done             = _lib.FT_Stroker_Done
+FT_Glyph_Stroke             = _lib.FT_Glyph_Stroke
+FT_Glyph_StrokeBorder       = _lib.FT_Glyph_StrokeBorder
+FT_Glyph_To_Bitmap          = _lib.FT_Glyph_To_Bitmap

--- a/freetype/raw.py
+++ b/freetype/raw.py
@@ -1,0 +1,137 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+#
+#  FreeType high-level python API - Copyright 2011-2014 Nicolas P. Rougier
+#  Distributed under the terms of the new BSD license.
+#
+# -----------------------------------------------------------------------------
+'''
+Freetype raw API
+
+This is the raw ctypes freetype binding.
+'''
+import os
+import platform
+from ctypes import *
+import ctypes.util
+
+from freetype.ft_types import *
+from freetype.ft_enums import *
+from freetype.ft_errors import *
+from freetype.ft_structs import *
+
+__dll__    = None
+
+# on windows all ctypes does when checking for the library
+# is to append .dll to the end and look for an exact match
+# within any entry in PATH.
+filename = ctypes.util.find_library('freetype')
+
+if filename is None:
+    if platform.system() == 'Windows':
+        # Check current working directory for dll as ctypes fails to do so
+        filename = os.path.join(os.path.realpath('.'), 'freetype.dll')
+    else:
+        filename = 'libfreetype.so.6'
+
+try:
+    dll = ctypes.CDLL(filename)
+    _found = True
+except (OSError, TypeError):
+    _found = False
+
+if not _found:
+    raise RuntimeError('Freetype library not found')
+
+__dll__ = dll
+
+FT_Init_FreeType       = __dll__.FT_Init_FreeType
+FT_Done_FreeType       = __dll__.FT_Done_FreeType
+FT_Library_Version     = __dll__.FT_Library_Version
+
+try:
+    FT_Library_SetLcdFilter= __dll__.FT_Library_SetLcdFilter
+except AttributeError:
+    def FT_Library_SetLcdFilter (*args, **kwargs):
+        return 0
+try:
+    FT_Library_SetLcdFilterWeights = __dll__.FT_Library_SetLcdFilterWeights
+except AttributeError:
+    pass
+
+FT_New_Face            = __dll__.FT_New_Face
+FT_New_Memory_Face     = __dll__.FT_New_Memory_Face
+FT_Open_Face           = __dll__.FT_Open_Face
+FT_Attach_File         = __dll__.FT_Attach_File
+FT_Attach_Stream       = __dll__.FT_Attach_Stream
+
+try:
+    FT_Reference_Face      = __dll__.FT_Reference_Face
+except AttributeError:
+	pass
+
+FT_Done_Face           = __dll__.FT_Done_Face
+FT_Done_Glyph          = __dll__.FT_Done_Glyph
+FT_Select_Size         = __dll__.FT_Select_Size
+FT_Request_Size        = __dll__.FT_Request_Size
+FT_Set_Char_Size       = __dll__.FT_Set_Char_Size
+FT_Set_Pixel_Sizes     = __dll__.FT_Set_Pixel_Sizes
+FT_Load_Glyph          = __dll__.FT_Load_Glyph
+FT_Load_Char           = __dll__.FT_Load_Char
+FT_Set_Transform       = __dll__.FT_Set_Transform
+FT_Render_Glyph        = __dll__.FT_Render_Glyph
+FT_Get_Kerning         = __dll__.FT_Get_Kerning
+FT_Get_Track_Kerning   = __dll__.FT_Get_Track_Kerning
+FT_Get_Glyph_Name      = __dll__.FT_Get_Glyph_Name
+FT_Get_Glyph           = __dll__.FT_Get_Glyph
+
+FT_Glyph_Get_CBox      = __dll__.FT_Glyph_Get_CBox
+
+FT_Get_Postscript_Name = __dll__.FT_Get_Postscript_Name
+FT_Get_Postscript_Name.restype = c_char_p
+FT_Select_Charmap      = __dll__.FT_Select_Charmap
+FT_Set_Charmap         = __dll__.FT_Set_Charmap
+FT_Get_Charmap_Index   = __dll__.FT_Get_Charmap_Index
+FT_Get_CMap_Language_ID= __dll__.FT_Get_CMap_Language_ID
+FT_Get_CMap_Format     = __dll__.FT_Get_CMap_Format
+FT_Get_Char_Index      = __dll__.FT_Get_Char_Index
+FT_Get_First_Char      = __dll__.FT_Get_First_Char
+FT_Get_Next_Char       = __dll__.FT_Get_Next_Char
+FT_Get_Name_Index      = __dll__.FT_Get_Name_Index
+FT_Get_SubGlyph_Info   = __dll__.FT_Get_SubGlyph_Info
+
+try:
+    FT_Get_FSType_Flags    = __dll__.FT_Get_FSType_Flags
+    FT_Get_FSType_Flags.restype  = c_ushort
+except AttributeError:
+	pass
+
+FT_Get_X11_Font_Format = __dll__.FT_Get_X11_Font_Format
+FT_Get_X11_Font_Format.restype = c_char_p
+
+FT_Get_Sfnt_Name_Count = __dll__.FT_Get_Sfnt_Name_Count
+FT_Get_Sfnt_Name       = __dll__.FT_Get_Sfnt_Name
+FT_Get_Advance         = __dll__.FT_Get_Advance
+
+
+FT_Outline_GetInsideBorder  = __dll__.FT_Outline_GetInsideBorder
+FT_Outline_GetOutsideBorder = __dll__.FT_Outline_GetOutsideBorder
+FT_Outline_Get_BBox         = __dll__.FT_Outline_Get_BBox
+FT_Outline_Get_CBox         = __dll__.FT_Outline_Get_CBox
+FT_Stroker_New              = __dll__.FT_Stroker_New
+FT_Stroker_Set              = __dll__.FT_Stroker_Set
+FT_Stroker_Rewind           = __dll__.FT_Stroker_Rewind
+FT_Stroker_ParseOutline     = __dll__.FT_Stroker_ParseOutline
+FT_Stroker_BeginSubPath     = __dll__.FT_Stroker_BeginSubPath
+FT_Stroker_EndSubPath       = __dll__.FT_Stroker_EndSubPath
+FT_Stroker_LineTo           = __dll__.FT_Stroker_LineTo
+FT_Stroker_ConicTo          = __dll__.FT_Stroker_ConicTo
+FT_Stroker_CubicTo          = __dll__.FT_Stroker_CubicTo
+FT_Stroker_GetBorderCounts  = __dll__.FT_Stroker_GetBorderCounts
+FT_Stroker_ExportBorder     = __dll__.FT_Stroker_ExportBorder
+FT_Stroker_GetCounts        = __dll__.FT_Stroker_GetCounts
+FT_Stroker_Export           = __dll__.FT_Stroker_Export
+FT_Stroker_Done             = __dll__.FT_Stroker_Done
+FT_Glyph_Stroke             = __dll__.FT_Glyph_Stroke
+FT_Glyph_StrokeBorder       = __dll__.FT_Glyph_StrokeBorder
+FT_Glyph_To_Bitmap          = __dll__.FT_Glyph_To_Bitmap


### PR DESCRIPTION
This should make things a bit better for people who want to use the ctypes binding directly, instead of the pythonic wrapper.

This still may need some work, and i haven't tested it thoroughly. 