### PR TITLE
Fix FT_Done_FreeType never being called on FT_Library instance.

### DIFF
--- a/freetype/__init__.py
+++ b/freetype/__init__.py
@@ -24,7 +24,7 @@ from freetype.raw import *
 PY3 = sys.version_info[0] == 3
 if PY3: unicode = str
 
-__handle__ = None
+_handle = None
 
 
 FT_Library_filename = filename
@@ -42,10 +42,10 @@ class _FT_Library_Wrapper(FT_Library):
         self._ft_done_freetype(self)
 
 def _init_freetype():
-    global __handle__
+    global _handle
 
-    __handle__ = _FT_Library_Wrapper()
-    error = FT_Init_FreeType( byref(__handle__) )
+    _handle = _FT_Library_Wrapper()
+    error = FT_Init_FreeType( byref(_handle) )
 
     if error: raise FT_Exception(error)
 
@@ -64,10 +64,10 @@ def get_handle():
     Get unique FT_Library handle
     '''
 
-    if not __handle__:
+    if not _handle:
         _init_freetype()
 
-    return __handle__
+    return _handle
 
 def version():
     '''

--- a/freetype/__init__.py
+++ b/freetype/__init__.py
@@ -29,34 +29,44 @@ __handle__ = None
 
 FT_Library_filename = filename
 
+class _FT_Library_Wrapper(FT_Library):
+    '''Subclass of FT_Library to help with calling FT_Done_FreeType'''
+    # for some reason this doesn't get carried over and ctypes complains
+    _type_ = FT_Library._type_
+
+    # Store ref to FT_Done_FreeType otherwise it will be deleted before needed.
+    _ft_done_freetype = FT_Done_FreeType
+
+    def __del__(self):
+        # call FT_Done_FreeType
+        self._ft_done_freetype(self)
+
+def _init_freetype():
+    global __handle__
+
+    __handle__ = _FT_Library_Wrapper()
+    error = FT_Init_FreeType( byref(__handle__) )
+
+    if error: raise FT_Exception(error)
+
+    try:
+        set_lcd_filter( FT_LCD_FILTER_DEFAULT )
+    except:
+        pass
+
 # -----------------------------------------------------------------------------
 # High-level API of FreeType 2
 # -----------------------------------------------------------------------------
 
-def __del_library__(self):
-    global __handle__
-    if __handle__:
-        try:
-            FT_Done_FreeType(self)
-            __handle__ = None
-        except:
-            pass
-FT_Library.__del__ = __del_library__
 
 def get_handle():
     '''
     Get unique FT_Library handle
     '''
-    global __handle__
+
     if not __handle__:
-        __handle__ = FT_Library( )
-        error = FT_Init_FreeType( byref(__handle__) )
-        if error: raise FT_Exception(error)
-        try:
-            set_lcd_filter( FT_LCD_FILTER_DEFAULT )
-        except:
-            pass
-        if error: raise FT_Exception(error)
+        _init_freetype()
+
     return __handle__
 
 def version():


### PR DESCRIPTION
In python 2 the injected \_\_del\_\_ method was called, but by the time FT_Library was deleted the FT\_Done\_FreeType function was gone. This has been worked around by storing a reference of FT\_Done\_FreeType.

However under python 3  there was a second issue. For whatever reason the injected \_\_del\_\_ method wasn't called at all. They work on a normal classes and subclasses in python 3, so I'm not completely sure what was going on there. Fixed this by just subclassing FT_Library, and defining the needed stuff in there.

This also has a nice side effect of no longer injecting the \_\_del\_\_ function into the raw FT_Library, which also effected anyone using freetype raw.