### PR TITLE
Binding rework

### DIFF
--- a/freetype/__init__.py
+++ b/freetype/__init__.py
@@ -27,8 +27,6 @@ if PY3: unicode = str
 _handle = None
 
 
-FT_Library_filename = filename
-
 class _FT_Library_Wrapper(FT_Library):
     '''Subclass of FT_Library to help with calling FT_Done_FreeType'''
     # for some reason this doesn't get carried over and ctypes complains

--- a/freetype/ft_enums/__init__.py
+++ b/freetype/ft_enums/__init__.py
@@ -109,6 +109,7 @@ from freetype.ft_enums.ft_render_modes import *
 from freetype.ft_enums.ft_stroker_borders import *
 from freetype.ft_enums.ft_stroker_linecaps import *
 from freetype.ft_enums.ft_stroker_linejoins import *
+from freetype.ft_enums.ft_size_request import *
 from freetype.ft_enums.ft_style_flags import *
 from freetype.ft_enums.tt_adobe_ids import *
 from freetype.ft_enums.tt_apple_ids import *

--- a/freetype/ft_enums/ft_size_request.py
+++ b/freetype/ft_enums/ft_size_request.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+
+FT_SIZE_REQUEST = { 'FT_SIZE_REQUEST_TYPE_NOMINAL': 0,
+                    'FT_SIZE_REQUEST_TYPE_REAL_DIM': 1,
+                    'FT_SIZE_REQUEST_TYPE_BBOX': 2,
+                    'FT_SIZE_REQUEST_TYPE_CELL': 3,
+                    'FT_SIZE_REQUEST_TYPE_SCALES': 4}
+
+globals().update(FT_SIZE_REQUEST)

--- a/freetype/ft_enums/ft_stroker_linejoins.py
+++ b/freetype/ft_enums/ft_stroker_linejoins.py
@@ -27,7 +27,10 @@ FT_STROKER_LINEJOIN_MITER
   the angle between the two joining lines is too closed (this is useful to
   avoid unpleasant spikes in beveled rendering).
 """
-FT_STROKER_LINEJOINS = { 'FT_STROKER_LINEJOIN_ROUND' : 0,
-                         'FT_STROKER_LINEJOIN_BEVEL' : 1,
-                         'FT_STROKER_LINEJOIN_MITER' : 2}
+FT_STROKER_LINEJOINS = { 'FT_STROKER_LINEJOIN_ROUND': 0,
+                         'FT_STROKER_LINEJOIN_BEVEL': 1,
+                         'FT_STROKER_LINEJOIN_MITER_VARIABLE': 2,
+    					 'FT_STROKER_LINEJOIN_MITER': 2,
+                         'FT_STROKER_LINEJOIN_MITER_FIXED': 3}
+
 globals().update(FT_STROKER_LINEJOINS)

--- a/freetype/ft_enums/ft_stroker_linejoins.py
+++ b/freetype/ft_enums/ft_stroker_linejoins.py
@@ -30,7 +30,7 @@ FT_STROKER_LINEJOIN_MITER
 FT_STROKER_LINEJOINS = { 'FT_STROKER_LINEJOIN_ROUND': 0,
                          'FT_STROKER_LINEJOIN_BEVEL': 1,
                          'FT_STROKER_LINEJOIN_MITER_VARIABLE': 2,
-    					 'FT_STROKER_LINEJOIN_MITER': 2,
+                         'FT_STROKER_LINEJOIN_MITER': 2,
                          'FT_STROKER_LINEJOIN_MITER_FIXED': 3}
 
 globals().update(FT_STROKER_LINEJOINS)

--- a/freetype/ft_structs.py
+++ b/freetype/ft_structs.py
@@ -28,7 +28,7 @@ FT_Generic: Client applications generic data.
 
 FT_Bitmap_Size: Metrics of a bitmap strike.
 
-FT_Charmap: The base charmap structure.
+FT_CharMap: The base charmap structure.
 
 FT_Glyph_Metrics:A structure used to model the metrics of a single glyph.
 
@@ -57,6 +57,8 @@ FT_SfntName: A structure used to model an SFNT 'name' table entry.
 FT_Stroker: Opaque handler to a path stroker object.
 
 FT_BitmapGlyph: A structure used for bitmap glyph images.
+
+FT_Size_Request: A structure used to model a size request.
 '''
 from freetype.ft_types import *
 
@@ -319,14 +321,31 @@ class FT_Bitmap_Size(Structure):
 
 # -----------------------------------------------------------------------------
 # The base charmap structure.
-class FT_CharmapRec(Structure):
+class FT_CharMapRec(Structure):
     '''
     The base charmap structure.
 
-    face : A handle to the parent face object.
+    A charmap is used to translate character codes in a given encoding into
+    glyph indexes for its parent's face. Some font formats may provide several
+    charmaps per font.
 
-    encoding : An FT_Encoding tag identifying the charmap. Use this with
-               FT_Select_Charmap.
+    Each face object owns zero or more charmaps, but only one of them can be
+    'active' and used by FT_Get_Char_Index or FT_Load_Char.
+
+    The list of available charmaps in a face is available through the
+    'face.num_charmaps' and 'face.charmaps' fields of FT_FaceRec.
+
+    The currently active charmap is available as 'face.charmap'. You should
+    call FT_Set_Charmap to change it.
+
+    When a new face is created (either through FT_New_Face or FT_Open_Face),
+    the library looks for a Unicode charmap within the list and automatically
+    activates it.
+
+    face: A handle to the parent face object.
+
+    encoding: An FT_Encoding tag identifying the charmap. Use this with
+              FT_Select_Charmap.
 
     platform_id: An ID number describing the platform for the following
                  encoding ID. This comes directly from the TrueType
@@ -335,13 +354,8 @@ class FT_CharmapRec(Structure):
     encoding_id: A platform specific encoding number. This also comes from the
                  TrueType specification and should be emulated similarly.
     '''
-    _fields_ = [
-        ('face',        c_void_p),  # Shoudl be FT_Face
-        ('encoding',    FT_Encoding),
-        ('platform_id', FT_UShort),
-        ('encoding_id', FT_UShort),
-        ]
-FT_Charmap = POINTER(FT_CharmapRec)
+    pass
+FT_CharMap = POINTER(FT_CharMapRec)
 
 
 
@@ -785,7 +799,7 @@ class FT_FaceRec(Structure):
           ('available_sizes', POINTER(FT_Bitmap_Size)),
 
           ('num_charmaps', c_int),
-          ('charmaps',     POINTER(FT_Charmap)),
+          ('charmaps',     POINTER(FT_CharMap)),
 
           ('generic', FT_Generic),
 
@@ -807,7 +821,7 @@ class FT_FaceRec(Structure):
 
           ('glyph',   FT_GlyphSlot),
           ('size',    FT_Size),
-          ('charmap', FT_Charmap),
+          ('charmap', FT_CharMap),
 
           # private
           ('driver',          c_void_p),
@@ -821,7 +835,13 @@ class FT_FaceRec(Structure):
     ]
 FT_Face = POINTER(FT_FaceRec)
 
-
+# fill out fields for FT_CharMap.
+FT_CharMap._fields_ = [
+    ('face', FT_Face),
+    ('encoding', FT_Encoding),
+    ('platform_id', FT_UShort),
+    ('encoding_id', FT_UShort)
+]
 
 # -----------------------------------------------------------------------------
 # A simple structure used to pass more or less generic parameters to
@@ -942,3 +962,28 @@ class FT_BitmapGlyphRec(Structure):
         ('bitmap', FT_Bitmap)
     ]
 FT_BitmapGlyph = POINTER(FT_BitmapGlyphRec)
+
+class FT_Size_RequestRec(Structure):
+    '''
+    A structure used to model a size request.
+
+    type: See FT_Size_Request_Type.
+
+    width: The desired width.
+
+    height: The desired height.
+
+    horiResolution: The horizontal resolution.  If set to zero, 'width' is
+                    treated as a 26.6 fractional pixel value.
+
+    vertResolution: The vertical resolution.  If set to zero, 'height' is
+                    treated as a 26.6 fractional pixel value.
+    '''
+    _fields_ = [
+        ('type', FT_Size_Request_Type),
+        ('width', FT_Long),
+        ('height', FT_Long),
+        ('horiResolution', FT_UInt),
+        ('vertResolution', FT_UInt)
+    ]
+FT_Size_Request = POINTER(FT_Size_RequestRec)

--- a/freetype/ft_structs.py
+++ b/freetype/ft_structs.py
@@ -835,8 +835,8 @@ class FT_FaceRec(Structure):
     ]
 FT_Face = POINTER(FT_FaceRec)
 
-# fill out fields for FT_CharMap.
-FT_CharMap._fields_ = [
+# fill out fields for FT_CharMapRec.
+FT_CharMapRec._fields_ = [
     ('face', FT_Face),
     ('encoding', FT_Encoding),
     ('platform_id', FT_UShort),

--- a/freetype/ft_types.py
+++ b/freetype/ft_types.py
@@ -153,6 +153,7 @@ FT_Size_Request_Type = c_int
 FT_StrokerBorder     = c_int
 FT_Stroker_LineCap   = c_int
 FT_Stroker_LineJoin  = c_int
+FT_LcdFilter         = c_int
 
 
 # Describe a function used to destroy the 'client' data of any FreeType

--- a/freetype/ft_types.py
+++ b/freetype/ft_types.py
@@ -147,7 +147,12 @@ FT_F26Dot6 = c_long   # A signed 26.6 fixed float type used for vectorial pixel
 
 FT_Glyph_Format = c_int
 
-FT_Encoding     = c_int
+FT_Encoding          = c_int
+FT_Render_Mode       = c_int
+FT_Size_Request_Type = c_int
+FT_StrokerBorder     = c_int
+FT_Stroker_LineCap   = c_int
+FT_Stroker_LineJoin  = c_int
 
 
 # Describe a function used to destroy the 'client' data of any FreeType

--- a/freetype/raw.py
+++ b/freetype/raw.py
@@ -23,8 +23,10 @@ from freetype.ft_structs import *
 # within any entry in PATH.
 filename = ctypes.util.find_library('freetype')
 
+osName = platform.system()
+
 if filename is None:
-    if platform.system() == 'Windows':
+    if osName == 'Windows':
         # Check current working directory for dll as ctypes fails to do so
         filename = os.path.join(os.path.realpath('.'), 'freetype.dll')
     else:
@@ -36,93 +38,207 @@ except (OSError, TypeError):
     _lib = None
     raise RuntimeError('Freetype library not found')
 
-FT_Init_FreeType       = _lib.FT_Init_FreeType
-FT_Done_FreeType       = _lib.FT_Done_FreeType
-FT_Library_Version     = _lib.FT_Library_Version
 
-try:
-    FT_Library_SetLcdFilter= _lib.FT_Library_SetLcdFilter
-except AttributeError:
-    def FT_Library_SetLcdFilter (*args, **kwargs):
-        return 0
-try:
-    FT_Library_SetLcdFilterWeights = _lib.FT_Library_SetLcdFilterWeights
-except AttributeError:
-    pass
+if osName == 'Windows':
+    _funcType = WINFUNCTYPE
+else: # Linux and OS X
+    _funcType = CFUNCTYPE
 
-FT_New_Face            = _lib.FT_New_Face
-FT_New_Memory_Face     = _lib.FT_New_Memory_Face
-FT_Open_Face           = _lib.FT_Open_Face
-FT_Attach_File         = _lib.FT_Attach_File
-FT_Attach_Stream       = _lib.FT_Attach_Stream
-
-try:
-    FT_Reference_Face      = _lib.FT_Reference_Face
-except AttributeError:
-	pass
-
-FT_Done_Face           = _lib.FT_Done_Face
-FT_Done_Glyph          = _lib.FT_Done_Glyph
-FT_Select_Size         = _lib.FT_Select_Size
-FT_Request_Size        = _lib.FT_Request_Size
-FT_Set_Char_Size       = _lib.FT_Set_Char_Size
-FT_Set_Pixel_Sizes     = _lib.FT_Set_Pixel_Sizes
-FT_Load_Glyph          = _lib.FT_Load_Glyph
-FT_Load_Char           = _lib.FT_Load_Char
-FT_Set_Transform       = _lib.FT_Set_Transform
-FT_Render_Glyph        = _lib.FT_Render_Glyph
-FT_Get_Kerning         = _lib.FT_Get_Kerning
-FT_Get_Track_Kerning   = _lib.FT_Get_Track_Kerning
-FT_Get_Glyph_Name      = _lib.FT_Get_Glyph_Name
-FT_Get_Glyph           = _lib.FT_Get_Glyph
-
-FT_Glyph_Get_CBox      = _lib.FT_Glyph_Get_CBox
-
-FT_Get_Postscript_Name = _lib.FT_Get_Postscript_Name
-FT_Get_Postscript_Name.restype = c_char_p
-FT_Select_Charmap      = _lib.FT_Select_Charmap
-FT_Set_Charmap         = _lib.FT_Set_Charmap
-FT_Get_Charmap_Index   = _lib.FT_Get_Charmap_Index
-FT_Get_CMap_Language_ID= _lib.FT_Get_CMap_Language_ID
-FT_Get_CMap_Format     = _lib.FT_Get_CMap_Format
-FT_Get_Char_Index      = _lib.FT_Get_Char_Index
-FT_Get_First_Char      = _lib.FT_Get_First_Char
-FT_Get_Next_Char       = _lib.FT_Get_Next_Char
-FT_Get_Name_Index      = _lib.FT_Get_Name_Index
-FT_Get_SubGlyph_Info   = _lib.FT_Get_SubGlyph_Info
-
-try:
-    FT_Get_FSType_Flags    = _lib.FT_Get_FSType_Flags
-    FT_Get_FSType_Flags.restype  = c_ushort
-except AttributeError:
-	pass
-
-FT_Get_X11_Font_Format = _lib.FT_Get_X11_Font_Format
-FT_Get_X11_Font_Format.restype = c_char_p
-
-FT_Get_Sfnt_Name_Count = _lib.FT_Get_Sfnt_Name_Count
-FT_Get_Sfnt_Name       = _lib.FT_Get_Sfnt_Name
-FT_Get_Advance         = _lib.FT_Get_Advance
+def _def_func(name, returnType, paramTypes):
+    '''Define function for library'''
+    try:
+        address = getattr(_lib, name)
+        function = _funcType(returnType, *paramTypes)
+    except AttributeError:
+        raise AttributeError('{}: Function not found.'.format(name))
+    return cast(address, function)
 
 
-FT_Outline_GetInsideBorder  = _lib.FT_Outline_GetInsideBorder
-FT_Outline_GetOutsideBorder = _lib.FT_Outline_GetOutsideBorder
-FT_Outline_Get_BBox         = _lib.FT_Outline_Get_BBox
-FT_Outline_Get_CBox         = _lib.FT_Outline_Get_CBox
-FT_Stroker_New              = _lib.FT_Stroker_New
-FT_Stroker_Set              = _lib.FT_Stroker_Set
-FT_Stroker_Rewind           = _lib.FT_Stroker_Rewind
-FT_Stroker_ParseOutline     = _lib.FT_Stroker_ParseOutline
-FT_Stroker_BeginSubPath     = _lib.FT_Stroker_BeginSubPath
-FT_Stroker_EndSubPath       = _lib.FT_Stroker_EndSubPath
-FT_Stroker_LineTo           = _lib.FT_Stroker_LineTo
-FT_Stroker_ConicTo          = _lib.FT_Stroker_ConicTo
-FT_Stroker_CubicTo          = _lib.FT_Stroker_CubicTo
-FT_Stroker_GetBorderCounts  = _lib.FT_Stroker_GetBorderCounts
-FT_Stroker_ExportBorder     = _lib.FT_Stroker_ExportBorder
-FT_Stroker_GetCounts        = _lib.FT_Stroker_GetCounts
-FT_Stroker_Export           = _lib.FT_Stroker_Export
-FT_Stroker_Done             = _lib.FT_Stroker_Done
-FT_Glyph_Stroke             = _lib.FT_Glyph_Stroke
-FT_Glyph_StrokeBorder       = _lib.FT_Glyph_StrokeBorder
-FT_Glyph_To_Bitmap          = _lib.FT_Glyph_To_Bitmap
+####### Functions/Macros ######
+
+##### FT_CONFIG_CONFIG_H #####
+##### FT_CONFIG_STANDARD_LIBRARY_H #####
+##### FT_CONFIG_OPTIONS_H #####
+##### FT_CONFIG_MODULES_H #####
+
+##### FT_FREETYPE_H #####
+#macros
+# FT_ENC_TAG
+# FT_HAS_HORIZONTAL
+# FT_HAS_VERTICAL
+# FT_HAS_KERNING
+# FT_IS_SCALABLE
+# FT_IS_SFNT
+# FT_IS_FIXED_WIDTH
+# FT_HAS_FIXED_SIZES
+# FT_HAS_FAST_GLYPHS
+# FT_HAS_GLYPH_NAMES
+# FT_HAS_MULTIPLE_MASTERS
+# FT_IS_CID_KEYED
+# FT_IS_TRICKY
+# FT_HAS_COLOR
+#end macros
+FT_Init_FreeType       = _def_func('FT_Init_FreeType', FT_Error, (POINTER(FT_Library),))
+FT_Done_FreeType       = _def_func('FT_Done_FreeType', FT_Error, (FT_Library,))
+FT_New_Face            = _def_func('FT_New_Face', FT_Error, (FT_Library, c_char_p, FT_Long, POINTER(FT_Face)))
+FT_New_Memory_Face     = _def_func('FT_New_Memory_Face', FT_Error, (FT_Library, POINTER(FT_Byte), FT_Long, FT_Long, POINTER(FT_Face)))
+FT_Open_Face           = _def_func('FT_Open_Face', FT_Error, (FT_Library, POINTER(FT_Open_Args), FT_Long, POINTER(FT_Face)))
+FT_Attach_File         = _def_func('FT_Attach_File', FT_Error, (FT_Face, c_char_p))
+FT_Attach_Stream       = _def_func('FT_Attach_Stream', FT_Error, (FT_Face, POINTER(FT_Open_Args)))
+FT_Reference_Face      = _def_func('FT_Reference_Face', FT_Error, (FT_Face,)) # 2.4.2+
+FT_Done_Face           = _def_func('FT_Done_Face', FT_Error, (FT_Face,))
+FT_Select_Size         = _def_func('FT_Select_Size', FT_Error, (FT_Face, FT_Int))
+FT_Request_Size        = _def_func('FT_Request_Size', FT_Error, (FT_Face, FT_Size_Request))
+FT_Set_Char_Size       = _def_func('FT_Set_Char_Size', FT_Error, (FT_Face, FT_F26Dot6, FT_F26Dot6, FT_UInt, FT_UInt))
+FT_Set_Pixel_Sizes     = _def_func('FT_Set_Pixel_Sizes', FT_Error, (FT_Face, FT_UInt, FT_UInt))
+FT_Load_Glyph          = _def_func('FT_Load_Glyph', FT_Error, (FT_Face, FT_UInt, FT_Int32))
+FT_Load_Char           = _def_func('FT_Load_Char', FT_Error, (FT_Face, FT_ULong, FT_Int32))
+FT_Set_Transform       = _def_func('FT_Set_Transform', None, (FT_Face, POINTER(FT_Matrix), POINTER(FT_Vector)))
+FT_Render_Glyph        = _def_func('FT_Render_Glyph', FT_Error, (FT_GlyphSlot, FT_Render_Mode))
+FT_Get_Kerning         = _def_func('FT_Get_Kerning', FT_Error, (FT_Face, FT_UInt, FT_UInt, FT_UInt, POINTER(FT_Vector)))
+FT_Get_Track_Kerning   = _def_func('FT_Get_Track_Kerning', FT_Error, (FT_Face, FT_Fixed, FT_Int, POINTER(FT_Fixed)))
+FT_Get_Glyph_Name      = _def_func('FT_Get_Glyph_Name', FT_Error, (FT_Face, FT_UInt, FT_Pointer, FT_UInt))
+FT_Get_Postscript_Name = _def_func('FT_Get_Postscript_Name', c_char_p, (FT_Face,))
+FT_Select_Charmap      = _def_func('FT_Select_Charmap', FT_Error, (FT_Face, FT_Encoding))
+FT_Set_Charmap         = _def_func('FT_Set_Charmap', FT_Error, (FT_Face, FT_CharMap))
+FT_Get_Charmap_Index   = _def_func('FT_Get_Charmap_Index', FT_Error, (FT_CharMap,))
+FT_Get_Char_Index      = _def_func('FT_Get_Char_Index', FT_UInt, (FT_Face, FT_ULong))
+FT_Get_First_Char      = _def_func('FT_Get_First_Char', FT_ULong, (FT_Face, FT_UInt))
+FT_Get_Next_Char       = _def_func('FT_Get_Next_Char', FT_ULong, (FT_Face, FT_ULong, POINTER(FT_UInt)))
+FT_Get_Name_Index      = _def_func('FT_Get_Name_Index', FT_UInt, (FT_Face, POINTER(FT_String)))
+FT_Get_SubGlyph_Info   = _def_func('FT_Get_SubGlyph_Info', FT_Error, (FT_GlyphSlot, FT_UInt, POINTER(FT_Int), POINTER(FT_UInt), POINTER(FT_Int), POINTER(FT_Int), POINTER(FT_Matrix)))
+FT_Get_FSType_Flags    = _def_func('FT_Get_FSType_Flags', FT_UShort, (FT_Face,)) # 2.3.8+
+# FT_Face_GetCharVariantIndex # 2.3.6+
+# FT_Face_GetCharVariantIsDefault # 2.3.6+
+# FT_Face_GetVariantSelectors # 2.3.6+
+# FT_Face_GetVariantsOfChar # 2.3.6+
+# FT_Face_GetCharsOfVariant # 2.3.6+
+# FT_MulDiv
+# FT_MulFix
+# FT_DivFix
+# FT_RoundFix
+# FT_CeilFix
+# FT_FloorFix
+# FT_Vector_Transform
+FT_Library_Version     = _def_func('FT_Library_Version', None, (FT_Library, POINTER(FT_Int), POINTER(FT_Int), POINTER(FT_Int)))
+# FT_Face_CheckTrueTypePatents # 2.3.5+
+# FT_Face_SetUnpatentedHinting # 2.3.5+
+
+##### FT_ERRORS_H #####
+##### FT_MODULE_ERRORS_H #####
+##### FT_SYSTEM_H #####
+##### FT_IMAGE_H #####
+##### FT_TYPES_H #####
+##### FT_LIST_H #####
+
+##### FT_OUTLINE_H #####
+# FT_Outline_Decompose
+# FT_Outline_New
+# FT_Outline_New_Internal
+# FT_Outline_Done
+# FT_Outline_Done_Internal
+# FT_Outline_Check
+FT_Outline_Get_CBox         = _def_func('FT_Outline_Get_CBox', POINTER(FT_Outline), (POINTER(FT_BBox),))
+# FT_Outline_Translate
+# FT_Outline_Copy
+# FT_Outline_Transform
+# FT_Outline_Embolden
+# FT_Outline_EmboldenXY
+# FT_Outline_Reverse
+# FT_Outline_Get_Bitmap
+# FT_Outline_Render
+# FT_Outline_Get_Orientation
+
+##### FT_SIZES_H #####
+##### FT_MODULE_H #####
+##### FT_RENDER_H #####
+##### FT_AUTOHINTER_H #####
+##### FT_CFF_DRIVER_H #####
+##### FT_TRUETYPE_DRIVER_H #####
+##### FT_TYPE1_TABLES_H #####
+##### FT_TRUETYPE_IDS_H #####
+
+##### FT_TRUETYPE_TABLES_H #####
+# FT_Get_Sfnt_Table
+# FT_Load_Sfnt_Table
+# FT_Sfnt_Table_Info
+FT_Get_CMap_Language_ID= _def_func('FT_Get_CMap_Language_ID', FT_ULong, (FT_CharMap,))
+FT_Get_CMap_Format     = _def_func('FT_Get_CMap_Format', FT_Long, (FT_CharMap,))
+
+##### FT_TRUETYPE_TAGS_H #####
+##### FT_BDF_H #####
+##### FT_CID_H #####
+##### FT_GZIP_H #####
+##### FT_LZW_H #####
+##### FT_BZIP2_H #####
+##### FT_WINFONTS_H #####
+
+##### FT_GLYPH_H #####
+FT_Get_Glyph           = _def_func('FT_Get_Glyph', FT_Error, (FT_Glyph, POINTER(FT_Glyph)))
+# FT_Glyph_Copy
+# FT_Glyph_Transform
+FT_Glyph_Get_CBox      = _def_func('FT_Glyph_Get_CBox', None, (FT_Glyph, FT_UInt, POINTER(FT_BBox)))
+FT_Glyph_To_Bitmap     = _def_func('FT_Glyph_To_Bitmap', FT_Error, (POINTER(FT_Glyph), FT_Render_Mode, POINTER(FT_Vector), FT_Bool))
+FT_Done_Glyph          = _def_func('FT_Done_Glyph', None, (FT_Glyph,))
+# FT_Matrix_Multiply
+# FT_Matrix_Invert
+
+##### FT_BITMAP_H #####
+
+##### FT_BBOX_H #####
+FT_Outline_Get_BBox         = _def_func('FT_Outline_Get_BBox', FT_Error, (POINTER(FT_Outline), POINTER(FT_BBox)))
+
+##### FT_CACHE_H #####
+##### FT_MAC_H #####
+##### FT_MULTIPLE_MASTERS_H #####
+
+##### FT_SFNT_NAMES_H #####
+FT_Get_Sfnt_Name_Count = _def_func('FT_Get_Sfnt_Name_Count', FT_UInt, (FT_Face,))
+FT_Get_Sfnt_Name       = _def_func('FT_Get_Sfnt_Name', FT_UInt, (FT_Face, FT_UInt, POINTER(FT_SfntName)))
+
+##### FT_OPENTYPE_VALIDATE_H #####
+##### FT_GX_VALIDATE_H #####
+##### FT_PFR_H #####
+
+##### FT_STROKER_H #####
+FT_Outline_GetInsideBorder  = _def_func('FT_Outline_GetInsideBorder', FT_StrokerBorder, (POINTER(FT_Outline),))
+FT_Outline_GetOutsideBorder = _def_func('FT_Outline_GetOutsideBorder', FT_StrokerBorder, (POINTER(FT_Outline),))
+FT_Stroker_New              = _def_func('FT_Stroker_New', FT_Error, (FT_Library, POINTER(FT_Stroker)))
+FT_Stroker_Set              = _def_func('FT_Stroker_Set', None, (FT_Stroker, FT_Fixed, FT_Stroker_LineCap, FT_Stroker_LineJoin, FT_Fixed))
+FT_Stroker_Rewind           = _def_func('FT_Stroker_Rewind', None, (FT_Stroker,) )
+FT_Stroker_ParseOutline     = _def_func('FT_Stroker_ParseOutline', FT_Error, (FT_Stroker, POINTER(FT_Outline), FT_Bool))
+FT_Stroker_BeginSubPath     = _def_func('FT_Stroker_BeginSubPath', FT_Error, (FT_Stroker, POINTER(FT_Vector), FT_Bool))
+FT_Stroker_EndSubPath       = _def_func('FT_Stroker_EndSubPath', FT_Error, (FT_Stroker,))
+FT_Stroker_LineTo           = _def_func('FT_Stroker_LineTo', FT_Error, (FT_Stroker, POINTER(FT_Vector)))
+FT_Stroker_ConicTo          = _def_func('FT_Stroker_ConicTo', FT_Error, (FT_Stroker, POINTER(FT_Vector), POINTER(FT_Vector)))
+FT_Stroker_CubicTo          = _def_func('FT_Stroker_CubicTo', FT_Error, (FT_Stroker, POINTER(FT_Vector), POINTER(FT_Vector), POINTER(FT_Vector)))
+FT_Stroker_GetBorderCounts  = _def_func('FT_Stroker_GetBorderCounts', FT_Error, (FT_Stroker, FT_StrokerBorder, POINTER(FT_UInt), POINTER(FT_UInt)))
+FT_Stroker_ExportBorder     = _def_func('FT_Stroker_ExportBorder', None, (FT_Stroker, FT_StrokerBorder, POINTER(FT_Outline)))
+FT_Stroker_GetCounts        = _def_func('FT_Stroker_GetCounts', FT_Error, (FT_Stroker, POINTER(FT_UInt), POINTER(FT_UInt)))
+FT_Stroker_Export           = _def_func('FT_Stroker_Export', None, (FT_Stroker, POINTER(FT_Outline)))
+FT_Stroker_Done             = _def_func('FT_Stroker_Done', None, (FT_Stroker,))
+FT_Glyph_Stroke             = _def_func('FT_Glyph_Stroke', FT_Error, (POINTER(FT_Glyph), FT_Stroker, FT_Bool))
+FT_Glyph_StrokeBorder       = _def_func('FT_Glyph_StrokeBorder', FT_Error, (POINTER(FT_Glyph), FT_Stroker, FT_Bool, FT_Bool))
+
+##### FT_SYNTHESIS_H #####
+
+##### FT_XFREE86_H #####
+FT_Get_X11_Font_Format = _def_func('FT_Get_X11_Font_Format', c_char_p, (FT_Face,))
+
+##### FT_TRIGONOMETRY_H #####
+
+##### FT_LCD_FILTER_H #####
+FT_Library_SetLcdFilter        = _def_func('FT_Library_SetLcdFilter', FT_Error, (FT_Library, FT_LcdFilter)) # 2.3.0+
+FT_Library_SetLcdFilterWeights = _def_func('FT_Library_SetLcdFilterWeights', FT_Error, (FT_Library, POINTER(c_ubyte))) # 2.4.0+
+
+##### FT_UNPATENTED_HINTING_H #####
+##### FT_INCREMENTAL_H #####
+##### FT_GASP_H #####
+
+##### FT_ADVANCES_H #####
+FT_Get_Advance     = _def_func('FT_Get_Advance', FT_Error, (FT_Face, FT_UInt, FT_Int32, POINTER(FT_Fixed)))
+# FT_Get_Advances
+
+##### FT_ERROR_DEFINITIONS_H #####
+##### FT_INCREMENTAL_H #####
+##### FT_TRUETYPE_UNPATENTED_H #####

--- a/freetype/raw.py
+++ b/freetype/raw.py
@@ -174,7 +174,7 @@ FT_Get_CMap_Format     = _def_func('FT_Get_CMap_Format', FT_Long, (FT_CharMap,))
 ##### FT_WINFONTS_H #####
 
 ##### FT_GLYPH_H #####
-FT_Get_Glyph           = _def_func('FT_Get_Glyph', FT_Error, (FT_Glyph, POINTER(FT_Glyph)))
+FT_Get_Glyph           = _def_func('FT_Get_Glyph', FT_Error, (FT_GlyphSlot, POINTER(FT_Glyph)))
 # FT_Glyph_Copy
 # FT_Glyph_Transform
 FT_Glyph_Get_CBox      = _def_func('FT_Glyph_Get_CBox', None, (FT_Glyph, FT_UInt, POINTER(FT_BBox)))

--- a/freetype/raw.py
+++ b/freetype/raw.py
@@ -12,6 +12,7 @@ import os
 import platform
 from ctypes import *
 import ctypes.util
+import warnings
 
 from freetype.ft_types import *
 from freetype.ft_enums import *
@@ -44,14 +45,82 @@ if osName == 'Windows':
 else: # Linux and OS X
     _funcType = CFUNCTYPE
 
-def _def_func(name, returnType, paramTypes):
+_version = None
+
+def _get_ft_version():
+
+    handle = FT_Library()
+    FT_Init_FreeType(byref(handle))
+    major = FT_Int(0)
+    minor = FT_Int(0)
+    patch = FT_Int(0)
+
+    FT_Library_Version(handle, byref(major), byref(minor), byref(patch))
+
+    FT_Done_FreeType(handle)
+
+    return (major.value, minor.value, patch.value)
+
+class _FTUndefinedFunction(object):
+    def __init__(self, name, version):
+        self.name = name
+        self.version = version
+
+    def __call__(self, *args, **kwargs):
+        reqStr = '.'.join(map(str, self.version))
+        verStr = '.'.join(map(str, _version))
+
+        message = 'The function {0} is not implemented in Freetype {1}' \
+                ', Freetype {2} or above is required.'.format(self.name,
+                verStr, reqStr)
+
+        warnings.simplefilter("always")
+        warnings.warn(message)
+        warnings.simplefilter("default")
+
+def _def_func(name, returnType, paramTypes, version=None):
     '''Define function for library'''
+    global _version
+
+    if version is not None:
+        if _version is None:
+            _version = _get_ft_version()
+
+        if not _version >= version:
+            verStr = '.'.join(map(str, _version))
+
+            message = 'FreeType {} installed, newer functionallity will ' \
+                    'not be available.'.format(verStr)
+
+            warnings.warn(message)
+            return _FTUndefinedFunction(name, version)
+
     try:
         address = getattr(_lib, name)
         function = _funcType(returnType, *paramTypes)
+
     except AttributeError:
         raise AttributeError('{}: Function not found.'.format(name))
+
     return cast(address, function)
+
+
+# functions needed to do version checking on the freetype library.
+# Need to be defined before any function requireing a specific version.
+FT_Init_FreeType    = _def_func(
+        'FT_Init_FreeType',
+         FT_Error,
+        (POINTER(FT_Library),))
+
+FT_Done_FreeType    = _def_func(
+        'FT_Done_FreeType',
+         FT_Error,
+        (FT_Library,))
+
+FT_Library_Version  = _def_func(
+        'FT_Library_Version',
+         None,
+        (FT_Library, POINTER(FT_Int), POINTER(FT_Int), POINTER(FT_Int)))
 
 
 ####### Functions/Macros ######
@@ -78,36 +147,151 @@ def _def_func(name, returnType, paramTypes):
 # FT_IS_TRICKY
 # FT_HAS_COLOR
 #end macros
-FT_Init_FreeType       = _def_func('FT_Init_FreeType', FT_Error, (POINTER(FT_Library),))
-FT_Done_FreeType       = _def_func('FT_Done_FreeType', FT_Error, (FT_Library,))
-FT_New_Face            = _def_func('FT_New_Face', FT_Error, (FT_Library, c_char_p, FT_Long, POINTER(FT_Face)))
-FT_New_Memory_Face     = _def_func('FT_New_Memory_Face', FT_Error, (FT_Library, POINTER(FT_Byte), FT_Long, FT_Long, POINTER(FT_Face)))
-FT_Open_Face           = _def_func('FT_Open_Face', FT_Error, (FT_Library, POINTER(FT_Open_Args), FT_Long, POINTER(FT_Face)))
-FT_Attach_File         = _def_func('FT_Attach_File', FT_Error, (FT_Face, c_char_p))
-FT_Attach_Stream       = _def_func('FT_Attach_Stream', FT_Error, (FT_Face, POINTER(FT_Open_Args)))
-FT_Reference_Face      = _def_func('FT_Reference_Face', FT_Error, (FT_Face,)) # 2.4.2+
-FT_Done_Face           = _def_func('FT_Done_Face', FT_Error, (FT_Face,))
-FT_Select_Size         = _def_func('FT_Select_Size', FT_Error, (FT_Face, FT_Int))
-FT_Request_Size        = _def_func('FT_Request_Size', FT_Error, (FT_Face, FT_Size_Request))
-FT_Set_Char_Size       = _def_func('FT_Set_Char_Size', FT_Error, (FT_Face, FT_F26Dot6, FT_F26Dot6, FT_UInt, FT_UInt))
-FT_Set_Pixel_Sizes     = _def_func('FT_Set_Pixel_Sizes', FT_Error, (FT_Face, FT_UInt, FT_UInt))
-FT_Load_Glyph          = _def_func('FT_Load_Glyph', FT_Error, (FT_Face, FT_UInt, FT_Int32))
-FT_Load_Char           = _def_func('FT_Load_Char', FT_Error, (FT_Face, FT_ULong, FT_Int32))
-FT_Set_Transform       = _def_func('FT_Set_Transform', None, (FT_Face, POINTER(FT_Matrix), POINTER(FT_Vector)))
-FT_Render_Glyph        = _def_func('FT_Render_Glyph', FT_Error, (FT_GlyphSlot, FT_Render_Mode))
-FT_Get_Kerning         = _def_func('FT_Get_Kerning', FT_Error, (FT_Face, FT_UInt, FT_UInt, FT_UInt, POINTER(FT_Vector)))
-FT_Get_Track_Kerning   = _def_func('FT_Get_Track_Kerning', FT_Error, (FT_Face, FT_Fixed, FT_Int, POINTER(FT_Fixed)))
-FT_Get_Glyph_Name      = _def_func('FT_Get_Glyph_Name', FT_Error, (FT_Face, FT_UInt, FT_Pointer, FT_UInt))
-FT_Get_Postscript_Name = _def_func('FT_Get_Postscript_Name', c_char_p, (FT_Face,))
-FT_Select_Charmap      = _def_func('FT_Select_Charmap', FT_Error, (FT_Face, FT_Encoding))
-FT_Set_Charmap         = _def_func('FT_Set_Charmap', FT_Error, (FT_Face, FT_CharMap))
-FT_Get_Charmap_Index   = _def_func('FT_Get_Charmap_Index', FT_Error, (FT_CharMap,))
-FT_Get_Char_Index      = _def_func('FT_Get_Char_Index', FT_UInt, (FT_Face, FT_ULong))
-FT_Get_First_Char      = _def_func('FT_Get_First_Char', FT_ULong, (FT_Face, FT_UInt))
-FT_Get_Next_Char       = _def_func('FT_Get_Next_Char', FT_ULong, (FT_Face, FT_ULong, POINTER(FT_UInt)))
-FT_Get_Name_Index      = _def_func('FT_Get_Name_Index', FT_UInt, (FT_Face, POINTER(FT_String)))
-FT_Get_SubGlyph_Info   = _def_func('FT_Get_SubGlyph_Info', FT_Error, (FT_GlyphSlot, FT_UInt, POINTER(FT_Int), POINTER(FT_UInt), POINTER(FT_Int), POINTER(FT_Int), POINTER(FT_Matrix)))
-FT_Get_FSType_Flags    = _def_func('FT_Get_FSType_Flags', FT_UShort, (FT_Face,)) # 2.3.8+
+# FT_Init_FreeType                    # defined earlier for version checking.
+# FT_Done_FreeType                    # defined earlier for version checking.
+FT_New_Face            = _def_func(
+        'FT_New_Face',
+        FT_Error,
+        (FT_Library, c_char_p, FT_Long, POINTER(FT_Face)))
+
+FT_New_Memory_Face     = _def_func(
+        'FT_New_Memory_Face',
+         FT_Error,
+        (FT_Library, POINTER(FT_Byte), FT_Long, FT_Long, POINTER(FT_Face)))
+
+FT_Open_Face           = _def_func(
+        'FT_Open_Face',
+         FT_Error,
+        (FT_Library, POINTER(FT_Open_Args), FT_Long, POINTER(FT_Face)))
+
+FT_Attach_File         = _def_func(
+        'FT_Attach_File',
+        FT_Error,
+        (FT_Face, c_char_p))
+
+FT_Attach_Stream       = _def_func(
+        'FT_Attach_Stream',
+        FT_Error,
+        (FT_Face, POINTER(FT_Open_Args)))
+
+FT_Reference_Face      = _def_func(
+        'FT_Reference_Face',
+        FT_Error,
+        (FT_Face,),
+         version=(2,4,2))
+
+FT_Done_Face           = _def_func(
+        'FT_Done_Face',
+        FT_Error,
+        (FT_Face,))
+
+FT_Select_Size         = _def_func(
+        'FT_Select_Size',
+        FT_Error,
+        (FT_Face, FT_Int))
+
+FT_Request_Size        = _def_func(
+        'FT_Request_Size',
+        FT_Error,
+        (FT_Face, FT_Size_Request))
+
+FT_Set_Char_Size       = _def_func(
+        'FT_Set_Char_Size',
+        FT_Error,
+        (FT_Face, FT_F26Dot6, FT_F26Dot6, FT_UInt, FT_UInt))
+
+FT_Set_Pixel_Sizes     = _def_func(
+        'FT_Set_Pixel_Sizes',
+        FT_Error,
+        (FT_Face, FT_UInt, FT_UInt))
+
+FT_Load_Glyph          = _def_func(
+        'FT_Load_Glyph',
+        FT_Error,
+        (FT_Face, FT_UInt, FT_Int32))
+
+FT_Load_Char           = _def_func(
+        'FT_Load_Char',
+        FT_Error,
+        (FT_Face, FT_ULong, FT_Int32))
+
+FT_Set_Transform       = _def_func(
+        'FT_Set_Transform',
+        None,
+        (FT_Face, POINTER(FT_Matrix), POINTER(FT_Vector)))
+
+FT_Render_Glyph        = _def_func(
+        'FT_Render_Glyph',
+        FT_Error,
+        (FT_GlyphSlot, FT_Render_Mode))
+
+FT_Get_Kerning         = _def_func(
+        'FT_Get_Kerning',
+        FT_Error,
+        (FT_Face, FT_UInt, FT_UInt, FT_UInt, POINTER(FT_Vector)))
+
+FT_Get_Track_Kerning   = _def_func(
+        'FT_Get_Track_Kerning',
+        FT_Error,
+        (FT_Face, FT_Fixed, FT_Int, POINTER(FT_Fixed)))
+
+FT_Get_Glyph_Name      = _def_func(
+        'FT_Get_Glyph_Name',
+        FT_Error,
+        (FT_Face, FT_UInt, FT_Pointer, FT_UInt))
+
+FT_Get_Postscript_Name = _def_func(
+        'FT_Get_Postscript_Name',
+        c_char_p,
+        (FT_Face,))
+
+FT_Select_Charmap      = _def_func(
+        'FT_Select_Charmap',
+        FT_Error,
+        (FT_Face, FT_Encoding))
+
+FT_Set_Charmap         = _def_func(
+        'FT_Set_Charmap',
+        FT_Error,
+        (FT_Face, FT_CharMap))
+
+FT_Get_Charmap_Index   = _def_func(
+        'FT_Get_Charmap_Index',
+        FT_Error,
+        (FT_CharMap,))
+
+FT_Get_Char_Index      = _def_func(
+        'FT_Get_Char_Index',
+        FT_UInt,
+        (FT_Face, FT_ULong))
+
+FT_Get_First_Char      = _def_func(
+        'FT_Get_First_Char',
+        FT_ULong,
+        (FT_Face, FT_UInt))
+
+FT_Get_Next_Char       = _def_func(
+        'FT_Get_Next_Char',
+        FT_ULong,
+        (FT_Face, FT_ULong, POINTER(FT_UInt)))
+
+FT_Get_Name_Index      = _def_func(
+        'FT_Get_Name_Index',
+        FT_UInt,
+        (FT_Face, POINTER(FT_String)))
+
+FT_Get_SubGlyph_Info   = _def_func(
+        'FT_Get_SubGlyph_Info',
+        FT_Error,
+        (FT_GlyphSlot, FT_UInt, POINTER(FT_Int), POINTER(FT_UInt),
+        POINTER(FT_Int), POINTER(FT_Int), POINTER(FT_Matrix)))
+
+FT_Get_FSType_Flags    = _def_func(
+        'FT_Get_FSType_Flags',
+        FT_UShort,
+        (FT_Face,),
+        version=(2,3,8))
+
 # FT_Face_GetCharVariantIndex # 2.3.6+
 # FT_Face_GetCharVariantIsDefault # 2.3.6+
 # FT_Face_GetVariantSelectors # 2.3.6+
@@ -120,7 +304,7 @@ FT_Get_FSType_Flags    = _def_func('FT_Get_FSType_Flags', FT_UShort, (FT_Face,))
 # FT_CeilFix
 # FT_FloorFix
 # FT_Vector_Transform
-FT_Library_Version     = _def_func('FT_Library_Version', None, (FT_Library, POINTER(FT_Int), POINTER(FT_Int), POINTER(FT_Int)))
+# FT_Library_Version                    # defined earlier for version checking.
 # FT_Face_CheckTrueTypePatents # 2.3.5+
 # FT_Face_SetUnpatentedHinting # 2.3.5+
 
@@ -138,7 +322,12 @@ FT_Library_Version     = _def_func('FT_Library_Version', None, (FT_Library, POIN
 # FT_Outline_Done
 # FT_Outline_Done_Internal
 # FT_Outline_Check
-FT_Outline_Get_CBox         = _def_func('FT_Outline_Get_CBox', POINTER(FT_Outline), (POINTER(FT_BBox),))
+
+FT_Outline_Get_CBox         = _def_func(
+        'FT_Outline_Get_CBox',
+        POINTER(FT_Outline),
+        (POINTER(FT_BBox),))
+
 # FT_Outline_Translate
 # FT_Outline_Copy
 # FT_Outline_Transform
@@ -162,8 +351,16 @@ FT_Outline_Get_CBox         = _def_func('FT_Outline_Get_CBox', POINTER(FT_Outlin
 # FT_Get_Sfnt_Table
 # FT_Load_Sfnt_Table
 # FT_Sfnt_Table_Info
-FT_Get_CMap_Language_ID= _def_func('FT_Get_CMap_Language_ID', FT_ULong, (FT_CharMap,))
-FT_Get_CMap_Format     = _def_func('FT_Get_CMap_Format', FT_Long, (FT_CharMap,))
+
+FT_Get_CMap_Language_ID  = _def_func(
+        'FT_Get_CMap_Language_ID',
+        FT_ULong,
+        (FT_CharMap,))
+
+FT_Get_CMap_Format       = _def_func(
+        'FT_Get_CMap_Format',
+        FT_Long,
+        (FT_CharMap,))
 
 ##### FT_TRUETYPE_TAGS_H #####
 ##### FT_BDF_H #####
@@ -174,69 +371,187 @@ FT_Get_CMap_Format     = _def_func('FT_Get_CMap_Format', FT_Long, (FT_CharMap,))
 ##### FT_WINFONTS_H #####
 
 ##### FT_GLYPH_H #####
-FT_Get_Glyph           = _def_func('FT_Get_Glyph', FT_Error, (FT_GlyphSlot, POINTER(FT_Glyph)))
+FT_Get_Glyph           = _def_func(
+        'FT_Get_Glyph',
+        FT_Error,
+        (FT_GlyphSlot, POINTER(FT_Glyph)))
+
 # FT_Glyph_Copy
 # FT_Glyph_Transform
-FT_Glyph_Get_CBox      = _def_func('FT_Glyph_Get_CBox', None, (FT_Glyph, FT_UInt, POINTER(FT_BBox)))
-FT_Glyph_To_Bitmap     = _def_func('FT_Glyph_To_Bitmap', FT_Error, (POINTER(FT_Glyph), FT_Render_Mode, POINTER(FT_Vector), FT_Bool))
-FT_Done_Glyph          = _def_func('FT_Done_Glyph', None, (FT_Glyph,))
+
+FT_Glyph_Get_CBox      = _def_func(
+        'FT_Glyph_Get_CBox',
+        None,
+        (FT_Glyph, FT_UInt, POINTER(FT_BBox)))
+
+FT_Glyph_To_Bitmap     = _def_func(
+        'FT_Glyph_To_Bitmap',
+        FT_Error,
+        (POINTER(FT_Glyph), FT_Render_Mode, POINTER(FT_Vector), FT_Bool))
+
+FT_Done_Glyph          = _def_func(
+        'FT_Done_Glyph',
+        None,
+        (FT_Glyph,))
+
 # FT_Matrix_Multiply
 # FT_Matrix_Invert
 
 ##### FT_BITMAP_H #####
 
 ##### FT_BBOX_H #####
-FT_Outline_Get_BBox         = _def_func('FT_Outline_Get_BBox', FT_Error, (POINTER(FT_Outline), POINTER(FT_BBox)))
+FT_Outline_Get_BBox         = _def_func(
+        'FT_Outline_Get_BBox',
+        FT_Error,
+        (POINTER(FT_Outline), POINTER(FT_BBox)))
+
 
 ##### FT_CACHE_H #####
 ##### FT_MAC_H #####
 ##### FT_MULTIPLE_MASTERS_H #####
 
 ##### FT_SFNT_NAMES_H #####
-FT_Get_Sfnt_Name_Count = _def_func('FT_Get_Sfnt_Name_Count', FT_UInt, (FT_Face,))
-FT_Get_Sfnt_Name       = _def_func('FT_Get_Sfnt_Name', FT_UInt, (FT_Face, FT_UInt, POINTER(FT_SfntName)))
+FT_Get_Sfnt_Name_Count = _def_func(
+        'FT_Get_Sfnt_Name_Count',
+        FT_UInt,
+        (FT_Face,))
+
+FT_Get_Sfnt_Name       = _def_func(
+        'FT_Get_Sfnt_Name',
+        FT_UInt,
+        (FT_Face, FT_UInt, POINTER(FT_SfntName)))
+
 
 ##### FT_OPENTYPE_VALIDATE_H #####
 ##### FT_GX_VALIDATE_H #####
 ##### FT_PFR_H #####
 
 ##### FT_STROKER_H #####
-FT_Outline_GetInsideBorder  = _def_func('FT_Outline_GetInsideBorder', FT_StrokerBorder, (POINTER(FT_Outline),))
-FT_Outline_GetOutsideBorder = _def_func('FT_Outline_GetOutsideBorder', FT_StrokerBorder, (POINTER(FT_Outline),))
-FT_Stroker_New              = _def_func('FT_Stroker_New', FT_Error, (FT_Library, POINTER(FT_Stroker)))
-FT_Stroker_Set              = _def_func('FT_Stroker_Set', None, (FT_Stroker, FT_Fixed, FT_Stroker_LineCap, FT_Stroker_LineJoin, FT_Fixed))
-FT_Stroker_Rewind           = _def_func('FT_Stroker_Rewind', None, (FT_Stroker,) )
-FT_Stroker_ParseOutline     = _def_func('FT_Stroker_ParseOutline', FT_Error, (FT_Stroker, POINTER(FT_Outline), FT_Bool))
-FT_Stroker_BeginSubPath     = _def_func('FT_Stroker_BeginSubPath', FT_Error, (FT_Stroker, POINTER(FT_Vector), FT_Bool))
-FT_Stroker_EndSubPath       = _def_func('FT_Stroker_EndSubPath', FT_Error, (FT_Stroker,))
-FT_Stroker_LineTo           = _def_func('FT_Stroker_LineTo', FT_Error, (FT_Stroker, POINTER(FT_Vector)))
-FT_Stroker_ConicTo          = _def_func('FT_Stroker_ConicTo', FT_Error, (FT_Stroker, POINTER(FT_Vector), POINTER(FT_Vector)))
-FT_Stroker_CubicTo          = _def_func('FT_Stroker_CubicTo', FT_Error, (FT_Stroker, POINTER(FT_Vector), POINTER(FT_Vector), POINTER(FT_Vector)))
-FT_Stroker_GetBorderCounts  = _def_func('FT_Stroker_GetBorderCounts', FT_Error, (FT_Stroker, FT_StrokerBorder, POINTER(FT_UInt), POINTER(FT_UInt)))
-FT_Stroker_ExportBorder     = _def_func('FT_Stroker_ExportBorder', None, (FT_Stroker, FT_StrokerBorder, POINTER(FT_Outline)))
-FT_Stroker_GetCounts        = _def_func('FT_Stroker_GetCounts', FT_Error, (FT_Stroker, POINTER(FT_UInt), POINTER(FT_UInt)))
-FT_Stroker_Export           = _def_func('FT_Stroker_Export', None, (FT_Stroker, POINTER(FT_Outline)))
-FT_Stroker_Done             = _def_func('FT_Stroker_Done', None, (FT_Stroker,))
-FT_Glyph_Stroke             = _def_func('FT_Glyph_Stroke', FT_Error, (POINTER(FT_Glyph), FT_Stroker, FT_Bool))
-FT_Glyph_StrokeBorder       = _def_func('FT_Glyph_StrokeBorder', FT_Error, (POINTER(FT_Glyph), FT_Stroker, FT_Bool, FT_Bool))
+FT_Outline_GetInsideBorder  = _def_func(
+        'FT_Outline_GetInsideBorder',
+        FT_StrokerBorder,
+        (POINTER(FT_Outline),))
+
+FT_Outline_GetOutsideBorder = _def_func(
+        'FT_Outline_GetOutsideBorder',
+        FT_StrokerBorder,
+        (POINTER(FT_Outline),))
+
+FT_Stroker_New              = _def_func(
+        'FT_Stroker_New',
+        FT_Error,
+        (FT_Library, POINTER(FT_Stroker)))
+
+FT_Stroker_Set              = _def_func(
+        'FT_Stroker_Set',
+        None,
+        (FT_Stroker, FT_Fixed, FT_Stroker_LineCap, FT_Stroker_LineJoin, FT_Fixed))
+
+FT_Stroker_Rewind           = _def_func(
+        'FT_Stroker_Rewind',
+        None,
+        (FT_Stroker,) )
+
+FT_Stroker_ParseOutline     = _def_func(
+        'FT_Stroker_ParseOutline',
+        FT_Error,
+        (FT_Stroker, POINTER(FT_Outline), FT_Bool))
+
+FT_Stroker_BeginSubPath     = _def_func(
+        'FT_Stroker_BeginSubPath',
+        FT_Error,
+        (FT_Stroker, POINTER(FT_Vector), FT_Bool))
+
+FT_Stroker_EndSubPath       = _def_func(
+        'FT_Stroker_EndSubPath',
+        FT_Error,
+        (FT_Stroker,))
+
+FT_Stroker_LineTo           = _def_func(
+        'FT_Stroker_LineTo',
+        FT_Error,
+        (FT_Stroker, POINTER(FT_Vector)))
+
+FT_Stroker_ConicTo          = _def_func(
+        'FT_Stroker_ConicTo',
+        FT_Error,
+        (FT_Stroker, POINTER(FT_Vector), POINTER(FT_Vector)))
+
+FT_Stroker_CubicTo          = _def_func(
+        'FT_Stroker_CubicTo',
+        FT_Error,
+        (FT_Stroker, POINTER(FT_Vector), POINTER(FT_Vector), POINTER(FT_Vector)))
+
+FT_Stroker_GetBorderCounts  = _def_func(
+        'FT_Stroker_GetBorderCounts',
+        FT_Error,
+        (FT_Stroker, FT_StrokerBorder, POINTER(FT_UInt), POINTER(FT_UInt)))
+
+FT_Stroker_ExportBorder     = _def_func(
+        'FT_Stroker_ExportBorder',
+        None,
+        (FT_Stroker, FT_StrokerBorder, POINTER(FT_Outline)))
+
+FT_Stroker_GetCounts        = _def_func(
+        'FT_Stroker_GetCounts',
+        FT_Error,
+        (FT_Stroker, POINTER(FT_UInt), POINTER(FT_UInt)))
+
+FT_Stroker_Export           = _def_func(
+        'FT_Stroker_Export',
+        None,
+        (FT_Stroker, POINTER(FT_Outline)))
+
+FT_Stroker_Done             = _def_func(
+        'FT_Stroker_Done',
+        None,
+        (FT_Stroker,))
+
+FT_Glyph_Stroke             = _def_func(
+        'FT_Glyph_Stroke',
+        FT_Error,
+        (POINTER(FT_Glyph), FT_Stroker, FT_Bool))
+
+FT_Glyph_StrokeBorder       = _def_func(
+        'FT_Glyph_StrokeBorder',
+        FT_Error,
+        (POINTER(FT_Glyph), FT_Stroker, FT_Bool, FT_Bool))
+
 
 ##### FT_SYNTHESIS_H #####
 
 ##### FT_XFREE86_H #####
-FT_Get_X11_Font_Format = _def_func('FT_Get_X11_Font_Format', c_char_p, (FT_Face,))
+FT_Get_X11_Font_Format = _def_func(
+        'FT_Get_X11_Font_Format',
+        c_char_p,
+        (FT_Face,))
 
 ##### FT_TRIGONOMETRY_H #####
 
 ##### FT_LCD_FILTER_H #####
-FT_Library_SetLcdFilter        = _def_func('FT_Library_SetLcdFilter', FT_Error, (FT_Library, FT_LcdFilter)) # 2.3.0+
-FT_Library_SetLcdFilterWeights = _def_func('FT_Library_SetLcdFilterWeights', FT_Error, (FT_Library, POINTER(c_ubyte))) # 2.4.0+
+FT_Library_SetLcdFilter        = _def_func(
+        'FT_Library_SetLcdFilter',
+        FT_Error,
+        (FT_Library, FT_LcdFilter),
+        version=(2,3,0))
+
+FT_Library_SetLcdFilterWeights = _def_func(
+        'FT_Library_SetLcdFilterWeights',
+        FT_Error,
+        (FT_Library, POINTER(c_ubyte)),
+        version=(2,4,0))
+
 
 ##### FT_UNPATENTED_HINTING_H #####
 ##### FT_INCREMENTAL_H #####
 ##### FT_GASP_H #####
 
 ##### FT_ADVANCES_H #####
-FT_Get_Advance     = _def_func('FT_Get_Advance', FT_Error, (FT_Face, FT_UInt, FT_Int32, POINTER(FT_Fixed)))
+FT_Get_Advance     = _def_func(
+        'FT_Get_Advance',
+        FT_Error,
+        (FT_Face, FT_UInt, FT_Int32, POINTER(FT_Fixed)))
+
 # FT_Get_Advances
 
 ##### FT_ERROR_DEFINITIONS_H #####

--- a/freetype/raw.py
+++ b/freetype/raw.py
@@ -78,8 +78,13 @@ class _FTUndefinedFunction(object):
         warnings.warn(message)
         warnings.simplefilter("default")
 
-def _def_func(name, returnType, paramTypes, version=None):
-    '''Define function for library'''
+def _ft_func(name, returnType, paramTypes, version=None):
+    '''
+    Define function for the freetype library
+
+    Version requirements can be set on functions which will
+    emit a warning for older freetype versions.
+    '''
     global _version
 
     if version is not None:
@@ -107,17 +112,17 @@ def _def_func(name, returnType, paramTypes, version=None):
 
 # functions needed to do version checking on the freetype library.
 # Need to be defined before any function requireing a specific version.
-FT_Init_FreeType    = _def_func(
+FT_Init_FreeType    = _ft_func(
         'FT_Init_FreeType',
          FT_Error,
         (POINTER(FT_Library),))
 
-FT_Done_FreeType    = _def_func(
+FT_Done_FreeType    = _ft_func(
         'FT_Done_FreeType',
          FT_Error,
         (FT_Library,))
 
-FT_Library_Version  = _def_func(
+FT_Library_Version  = _ft_func(
         'FT_Library_Version',
          None,
         (FT_Library, POINTER(FT_Int), POINTER(FT_Int), POINTER(FT_Int)))
@@ -149,144 +154,144 @@ FT_Library_Version  = _def_func(
 #end macros
 # FT_Init_FreeType                    # defined earlier for version checking.
 # FT_Done_FreeType                    # defined earlier for version checking.
-FT_New_Face            = _def_func(
+FT_New_Face            = _ft_func(
         'FT_New_Face',
         FT_Error,
         (FT_Library, c_char_p, FT_Long, POINTER(FT_Face)))
 
-FT_New_Memory_Face     = _def_func(
+FT_New_Memory_Face     = _ft_func(
         'FT_New_Memory_Face',
          FT_Error,
         (FT_Library, POINTER(FT_Byte), FT_Long, FT_Long, POINTER(FT_Face)))
 
-FT_Open_Face           = _def_func(
+FT_Open_Face           = _ft_func(
         'FT_Open_Face',
          FT_Error,
         (FT_Library, POINTER(FT_Open_Args), FT_Long, POINTER(FT_Face)))
 
-FT_Attach_File         = _def_func(
+FT_Attach_File         = _ft_func(
         'FT_Attach_File',
         FT_Error,
         (FT_Face, c_char_p))
 
-FT_Attach_Stream       = _def_func(
+FT_Attach_Stream       = _ft_func(
         'FT_Attach_Stream',
         FT_Error,
         (FT_Face, POINTER(FT_Open_Args)))
 
-FT_Reference_Face      = _def_func(
+FT_Reference_Face      = _ft_func(
         'FT_Reference_Face',
         FT_Error,
         (FT_Face,),
          version=(2,4,2))
 
-FT_Done_Face           = _def_func(
+FT_Done_Face           = _ft_func(
         'FT_Done_Face',
         FT_Error,
         (FT_Face,))
 
-FT_Select_Size         = _def_func(
+FT_Select_Size         = _ft_func(
         'FT_Select_Size',
         FT_Error,
         (FT_Face, FT_Int))
 
-FT_Request_Size        = _def_func(
+FT_Request_Size        = _ft_func(
         'FT_Request_Size',
         FT_Error,
         (FT_Face, FT_Size_Request))
 
-FT_Set_Char_Size       = _def_func(
+FT_Set_Char_Size       = _ft_func(
         'FT_Set_Char_Size',
         FT_Error,
         (FT_Face, FT_F26Dot6, FT_F26Dot6, FT_UInt, FT_UInt))
 
-FT_Set_Pixel_Sizes     = _def_func(
+FT_Set_Pixel_Sizes     = _ft_func(
         'FT_Set_Pixel_Sizes',
         FT_Error,
         (FT_Face, FT_UInt, FT_UInt))
 
-FT_Load_Glyph          = _def_func(
+FT_Load_Glyph          = _ft_func(
         'FT_Load_Glyph',
         FT_Error,
         (FT_Face, FT_UInt, FT_Int32))
 
-FT_Load_Char           = _def_func(
+FT_Load_Char           = _ft_func(
         'FT_Load_Char',
         FT_Error,
         (FT_Face, FT_ULong, FT_Int32))
 
-FT_Set_Transform       = _def_func(
+FT_Set_Transform       = _ft_func(
         'FT_Set_Transform',
         None,
         (FT_Face, POINTER(FT_Matrix), POINTER(FT_Vector)))
 
-FT_Render_Glyph        = _def_func(
+FT_Render_Glyph        = _ft_func(
         'FT_Render_Glyph',
         FT_Error,
         (FT_GlyphSlot, FT_Render_Mode))
 
-FT_Get_Kerning         = _def_func(
+FT_Get_Kerning         = _ft_func(
         'FT_Get_Kerning',
         FT_Error,
         (FT_Face, FT_UInt, FT_UInt, FT_UInt, POINTER(FT_Vector)))
 
-FT_Get_Track_Kerning   = _def_func(
+FT_Get_Track_Kerning   = _ft_func(
         'FT_Get_Track_Kerning',
         FT_Error,
         (FT_Face, FT_Fixed, FT_Int, POINTER(FT_Fixed)))
 
-FT_Get_Glyph_Name      = _def_func(
+FT_Get_Glyph_Name      = _ft_func(
         'FT_Get_Glyph_Name',
         FT_Error,
         (FT_Face, FT_UInt, FT_Pointer, FT_UInt))
 
-FT_Get_Postscript_Name = _def_func(
+FT_Get_Postscript_Name = _ft_func(
         'FT_Get_Postscript_Name',
         c_char_p,
         (FT_Face,))
 
-FT_Select_Charmap      = _def_func(
+FT_Select_Charmap      = _ft_func(
         'FT_Select_Charmap',
         FT_Error,
         (FT_Face, FT_Encoding))
 
-FT_Set_Charmap         = _def_func(
+FT_Set_Charmap         = _ft_func(
         'FT_Set_Charmap',
         FT_Error,
         (FT_Face, FT_CharMap))
 
-FT_Get_Charmap_Index   = _def_func(
+FT_Get_Charmap_Index   = _ft_func(
         'FT_Get_Charmap_Index',
         FT_Error,
         (FT_CharMap,))
 
-FT_Get_Char_Index      = _def_func(
+FT_Get_Char_Index      = _ft_func(
         'FT_Get_Char_Index',
         FT_UInt,
         (FT_Face, FT_ULong))
 
-FT_Get_First_Char      = _def_func(
+FT_Get_First_Char      = _ft_func(
         'FT_Get_First_Char',
         FT_ULong,
         (FT_Face, FT_UInt))
 
-FT_Get_Next_Char       = _def_func(
+FT_Get_Next_Char       = _ft_func(
         'FT_Get_Next_Char',
         FT_ULong,
         (FT_Face, FT_ULong, POINTER(FT_UInt)))
 
-FT_Get_Name_Index      = _def_func(
+FT_Get_Name_Index      = _ft_func(
         'FT_Get_Name_Index',
         FT_UInt,
         (FT_Face, POINTER(FT_String)))
 
-FT_Get_SubGlyph_Info   = _def_func(
+FT_Get_SubGlyph_Info   = _ft_func(
         'FT_Get_SubGlyph_Info',
         FT_Error,
         (FT_GlyphSlot, FT_UInt, POINTER(FT_Int), POINTER(FT_UInt),
         POINTER(FT_Int), POINTER(FT_Int), POINTER(FT_Matrix)))
 
-FT_Get_FSType_Flags    = _def_func(
+FT_Get_FSType_Flags    = _ft_func(
         'FT_Get_FSType_Flags',
         FT_UShort,
         (FT_Face,),
@@ -323,7 +328,7 @@ FT_Get_FSType_Flags    = _def_func(
 # FT_Outline_Done_Internal
 # FT_Outline_Check
 
-FT_Outline_Get_CBox         = _def_func(
+FT_Outline_Get_CBox         = _ft_func(
         'FT_Outline_Get_CBox',
         POINTER(FT_Outline),
         (POINTER(FT_BBox),))
@@ -352,12 +357,12 @@ FT_Outline_Get_CBox         = _def_func(
 # FT_Load_Sfnt_Table
 # FT_Sfnt_Table_Info
 
-FT_Get_CMap_Language_ID  = _def_func(
+FT_Get_CMap_Language_ID  = _ft_func(
         'FT_Get_CMap_Language_ID',
         FT_ULong,
         (FT_CharMap,))
 
-FT_Get_CMap_Format       = _def_func(
+FT_Get_CMap_Format       = _ft_func(
         'FT_Get_CMap_Format',
         FT_Long,
         (FT_CharMap,))
@@ -371,7 +376,7 @@ FT_Get_CMap_Format       = _def_func(
 ##### FT_WINFONTS_H #####
 
 ##### FT_GLYPH_H #####
-FT_Get_Glyph           = _def_func(
+FT_Get_Glyph           = _ft_func(
         'FT_Get_Glyph',
         FT_Error,
         (FT_GlyphSlot, POINTER(FT_Glyph)))
@@ -379,17 +384,17 @@ FT_Get_Glyph           = _def_func(
 # FT_Glyph_Copy
 # FT_Glyph_Transform
 
-FT_Glyph_Get_CBox      = _def_func(
+FT_Glyph_Get_CBox      = _ft_func(
         'FT_Glyph_Get_CBox',
         None,
         (FT_Glyph, FT_UInt, POINTER(FT_BBox)))
 
-FT_Glyph_To_Bitmap     = _def_func(
+FT_Glyph_To_Bitmap     = _ft_func(
         'FT_Glyph_To_Bitmap',
         FT_Error,
         (POINTER(FT_Glyph), FT_Render_Mode, POINTER(FT_Vector), FT_Bool))
 
-FT_Done_Glyph          = _def_func(
+FT_Done_Glyph          = _ft_func(
         'FT_Done_Glyph',
         None,
         (FT_Glyph,))
@@ -400,7 +405,7 @@ FT_Done_Glyph          = _def_func(
 ##### FT_BITMAP_H #####
 
 ##### FT_BBOX_H #####
-FT_Outline_Get_BBox         = _def_func(
+FT_Outline_Get_BBox         = _ft_func(
         'FT_Outline_Get_BBox',
         FT_Error,
         (POINTER(FT_Outline), POINTER(FT_BBox)))
@@ -411,12 +416,12 @@ FT_Outline_Get_BBox         = _def_func(
 ##### FT_MULTIPLE_MASTERS_H #####
 
 ##### FT_SFNT_NAMES_H #####
-FT_Get_Sfnt_Name_Count = _def_func(
+FT_Get_Sfnt_Name_Count = _ft_func(
         'FT_Get_Sfnt_Name_Count',
         FT_UInt,
         (FT_Face,))
 
-FT_Get_Sfnt_Name       = _def_func(
+FT_Get_Sfnt_Name       = _ft_func(
         'FT_Get_Sfnt_Name',
         FT_UInt,
         (FT_Face, FT_UInt, POINTER(FT_SfntName)))
@@ -427,92 +432,92 @@ FT_Get_Sfnt_Name       = _def_func(
 ##### FT_PFR_H #####
 
 ##### FT_STROKER_H #####
-FT_Outline_GetInsideBorder  = _def_func(
+FT_Outline_GetInsideBorder  = _ft_func(
         'FT_Outline_GetInsideBorder',
         FT_StrokerBorder,
         (POINTER(FT_Outline),))
 
-FT_Outline_GetOutsideBorder = _def_func(
+FT_Outline_GetOutsideBorder = _ft_func(
         'FT_Outline_GetOutsideBorder',
         FT_StrokerBorder,
         (POINTER(FT_Outline),))
 
-FT_Stroker_New              = _def_func(
+FT_Stroker_New              = _ft_func(
         'FT_Stroker_New',
         FT_Error,
         (FT_Library, POINTER(FT_Stroker)))
 
-FT_Stroker_Set              = _def_func(
+FT_Stroker_Set              = _ft_func(
         'FT_Stroker_Set',
         None,
         (FT_Stroker, FT_Fixed, FT_Stroker_LineCap, FT_Stroker_LineJoin, FT_Fixed))
 
-FT_Stroker_Rewind           = _def_func(
+FT_Stroker_Rewind           = _ft_func(
         'FT_Stroker_Rewind',
         None,
         (FT_Stroker,) )
 
-FT_Stroker_ParseOutline     = _def_func(
+FT_Stroker_ParseOutline     = _ft_func(
         'FT_Stroker_ParseOutline',
         FT_Error,
         (FT_Stroker, POINTER(FT_Outline), FT_Bool))
 
-FT_Stroker_BeginSubPath     = _def_func(
+FT_Stroker_BeginSubPath     = _ft_func(
         'FT_Stroker_BeginSubPath',
         FT_Error,
         (FT_Stroker, POINTER(FT_Vector), FT_Bool))
 
-FT_Stroker_EndSubPath       = _def_func(
+FT_Stroker_EndSubPath       = _ft_func(
         'FT_Stroker_EndSubPath',
         FT_Error,
         (FT_Stroker,))
 
-FT_Stroker_LineTo           = _def_func(
+FT_Stroker_LineTo           = _ft_func(
         'FT_Stroker_LineTo',
         FT_Error,
         (FT_Stroker, POINTER(FT_Vector)))
 
-FT_Stroker_ConicTo          = _def_func(
+FT_Stroker_ConicTo          = _ft_func(
         'FT_Stroker_ConicTo',
         FT_Error,
         (FT_Stroker, POINTER(FT_Vector), POINTER(FT_Vector)))
 
-FT_Stroker_CubicTo          = _def_func(
+FT_Stroker_CubicTo          = _ft_func(
         'FT_Stroker_CubicTo',
         FT_Error,
         (FT_Stroker, POINTER(FT_Vector), POINTER(FT_Vector), POINTER(FT_Vector)))
 
-FT_Stroker_GetBorderCounts  = _def_func(
+FT_Stroker_GetBorderCounts  = _ft_func(
         'FT_Stroker_GetBorderCounts',
         FT_Error,
         (FT_Stroker, FT_StrokerBorder, POINTER(FT_UInt), POINTER(FT_UInt)))
 
-FT_Stroker_ExportBorder     = _def_func(
+FT_Stroker_ExportBorder     = _ft_func(
         'FT_Stroker_ExportBorder',
         None,
         (FT_Stroker, FT_StrokerBorder, POINTER(FT_Outline)))
 
-FT_Stroker_GetCounts        = _def_func(
+FT_Stroker_GetCounts        = _ft_func(
         'FT_Stroker_GetCounts',
         FT_Error,
         (FT_Stroker, POINTER(FT_UInt), POINTER(FT_UInt)))
 
-FT_Stroker_Export           = _def_func(
+FT_Stroker_Export           = _ft_func(
         'FT_Stroker_Export',
         None,
         (FT_Stroker, POINTER(FT_Outline)))
 
-FT_Stroker_Done             = _def_func(
+FT_Stroker_Done             = _ft_func(
         'FT_Stroker_Done',
         None,
         (FT_Stroker,))
 
-FT_Glyph_Stroke             = _def_func(
+FT_Glyph_Stroke             = _ft_func(
         'FT_Glyph_Stroke',
         FT_Error,
         (POINTER(FT_Glyph), FT_Stroker, FT_Bool))
 
-FT_Glyph_StrokeBorder       = _def_func(
+FT_Glyph_StrokeBorder       = _ft_func(
         'FT_Glyph_StrokeBorder',
         FT_Error,
         (POINTER(FT_Glyph), FT_Stroker, FT_Bool, FT_Bool))
@@ -521,7 +526,7 @@ FT_Glyph_StrokeBorder       = _def_func(
 ##### FT_SYNTHESIS_H #####
 
 ##### FT_XFREE86_H #####
-FT_Get_X11_Font_Format = _def_func(
+FT_Get_X11_Font_Format = _ft_func(
         'FT_Get_X11_Font_Format',
         c_char_p,
         (FT_Face,))
@@ -529,13 +534,13 @@ FT_Get_X11_Font_Format = _def_func(
 ##### FT_TRIGONOMETRY_H #####
 
 ##### FT_LCD_FILTER_H #####
-FT_Library_SetLcdFilter        = _def_func(
+FT_Library_SetLcdFilter        = _ft_func(
         'FT_Library_SetLcdFilter',
         FT_Error,
         (FT_Library, FT_LcdFilter),
         version=(2,3,0))
 
-FT_Library_SetLcdFilterWeights = _def_func(
+FT_Library_SetLcdFilterWeights = _ft_func(
         'FT_Library_SetLcdFilterWeights',
         FT_Error,
         (FT_Library, POINTER(c_ubyte)),
@@ -547,7 +552,7 @@ FT_Library_SetLcdFilterWeights = _def_func(
 ##### FT_GASP_H #####
 
 ##### FT_ADVANCES_H #####
-FT_Get_Advance     = _def_func(
+FT_Get_Advance     = _ft_func(
         'FT_Get_Advance',
         FT_Error,
         (FT_Face, FT_UInt, FT_Int32, POINTER(FT_Fixed)))

--- a/freetype/utils.py
+++ b/freetype/utils.py
@@ -1,0 +1,170 @@
+import ctypes as ct
+
+import os
+import platform
+import ctypes.util
+import warnings
+
+from freetype.ft_structs import FT_Library
+from freetype.ft_types import FT_Int
+
+# on windows all ctypes does when checking for the library
+# is to append .dll to the end and look for an exact match
+# within any entry in PATH.
+filename = ct.util.find_library('freetype')
+
+osName = platform.system()
+
+if filename is None:
+    if osName == 'Windows':
+        # Check current working directory for dll as ctypes fails to do so
+        filename = os.path.join(os.path.realpath('.'), 'freetype.dll')
+    else:
+        filename = 'libfreetype.so.6'
+
+try:
+    _lib = ct.CDLL(filename)
+except (OSError, TypeError):
+    _lib = None
+    raise RuntimeError('Freetype library not found')
+
+
+if osName == 'Windows':
+    _funcType = ct.WINFUNCTYPE
+else: # Linux and OS X
+    _funcType = ct.CFUNCTYPE
+
+_version = None
+
+
+# functions needed to do version checking on the freetype library.
+FT_Init_FreeType   = _lib.FT_Init_FreeType
+FT_Done_FreeType   = _lib.FT_Done_FreeType
+FT_Library_Version = _lib.FT_Library_Version
+
+def _get_ft_version():
+
+    handle = FT_Library()
+    FT_Init_FreeType(ct.byref(handle))
+    major = FT_Int(0)
+    minor = FT_Int(0)
+    patch = FT_Int(0)
+
+    FT_Library_Version(handle, ct.byref(major), ct.byref(minor), ct.byref(patch))
+
+    FT_Done_FreeType(handle)
+
+    return (major.value, minor.value, patch.value)
+
+class _FTUndefinedFunction(object):
+    def __init__(self, name, version):
+        self.name = name
+        self.version = version
+
+    def __call__(self, *args, **kwargs):
+        reqStr = '.'.join(map(str, self.version))
+        verStr = '.'.join(map(str, _version))
+
+        message = 'The function {0} is not implemented in Freetype {1}' \
+                ', Freetype {2} or above is required.'.format(self.name,
+                verStr, reqStr)
+
+        warnings.simplefilter("always")
+        warnings.warn(message)
+        warnings.simplefilter("default")
+
+def _ft_func(name, returnType, paramTypes, version=None):
+    '''
+    Define function for the freetype library
+
+    Version requirements can be set on functions which will
+    emit a warning for older freetype versions.
+    '''
+    global _version
+
+    if version is not None:
+        if _version is None:
+            _version = _get_ft_version()
+
+        if not _version >= version:
+            verStr = '.'.join(map(str, _version))
+
+            message = 'FreeType {} installed, newer functionallity will ' \
+                    'not be available.'.format(verStr)
+
+            warnings.warn(message)
+            return _FTUndefinedFunction(name, version)
+
+    try:
+        address = getattr(_lib, name)
+        function = _funcType(returnType, *paramTypes)
+
+    except AttributeError:
+        raise AttributeError('{}: Function not found.'.format(name))
+
+    return ct.cast(address, function)
+
+
+class EnumTypeBase(object):
+    def __init__(self, name, value):
+        self._name = name
+        self._value = value
+
+        self._as_parameter_ = ct.c_int(self.value)
+
+    @property
+    def value(self):
+        return self._value
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def type(self):
+        return self._type
+
+    @classmethod
+    def from_param(cls, obj):
+        try:
+            if obj.type == cls._type:
+                return obj._as_parameter_
+            else:
+                raise TypeError('Incorrect enum type.')
+        except AttributeError:
+            if not isinstance(obj, EnumWrapper) and obj.type != self.type:
+                raise TypeError('Incorrect type.')
+            else:
+                raise
+
+class Enum(object):
+
+    def __init__(self, enumType, enums):
+
+        self.type = enumType
+
+        self.enums = {}
+
+        enumCounter = 0
+
+        EnumClass = type(enumType, (EnumTypeBase,), {'_type': enumType})
+
+        for i, enum in enumerate(enums):
+            enumSplit = enum.split('=')
+
+            splitNum = len(enumSplit)
+
+            if splitNum == 2:
+                enumCounter = int(enumSplit[1])
+
+            elif splitNum > 2:
+                raise SyntaxError('Enum {0} Incorrect enum syntax.'.format(i+1))
+            
+            else:
+                enumCounter += 1
+
+            self.enums[enumSplit[0]] = EnumClass(enumSplit[0], enumCounter)
+
+        self.enums[self.type] = EnumClass
+
+        globals().update(self.enums)


### PR DESCRIPTION
I was having some annoyances when using the raw api by itself some hard to fix bugs because of python segmentation faults. So i decided to go through and redo the ctypes binding a bit. Things should be a lot less fragile when using it standalone now.

There are still a couple of thing i need to do. As it stands if you try to use an older version of freetype you will most likely get an error on import because of it unable to find a newer function. I want to get that fixed before this is merged.

Eventually I'd like to go through and fill out more of the freetype api than what is defined so far just so things are more complete. For that i went and put comments of the names that freetype gives its headers. Then for headers that already had some functions defined from it i went and put a comment with the names of functions not yet defined.

Also for the binding function i could use the restype and argtypes method, but i just generally prefer to do it the way i did in the code if I'm writing a function that does the stuff.

So in short don't quite merge yet one thing i still need to do, just putting the pull request up for any comments for now.