### PR TITLE
Added FT_LOAD_COLOR to load color version emoji

### DIFF
--- a/examples/emoji-color.py
+++ b/examples/emoji-color.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+import freetype
+import numpy as np
+from PIL import Image
+
+def convert_bgra_to_rgb(buf):
+    blue = buf[:,:,0]
+    green = buf[:,:,1]
+    red = buf[:,:,2]
+    return np.dstack((red, green, blue))
+
+face = freetype.Face("/System/Library/Fonts/Apple Color Emoji.ttc")
+face.set_char_size( 20*64 )
+face.load_char('😀', freetype.FT_LOAD_COLOR)
+bitmap = face.glyph.bitmap
+bitmap = np.array(bitmap.buffer, dtype=np.uint8).reshape((bitmap.rows,bitmap.width,4))
+rgb = convert_bgra_to_rgb(bitmap)
+im = Image.fromarray(rgb)
+im.show()

--- a/freetype/ft_enums/ft_load_flags.py
+++ b/freetype/ft_enums/ft_load_flags.py
@@ -133,6 +133,15 @@ FT_LOAD_LINEAR_DESIGN
 FT_LOAD_NO_AUTOHINT
 
   Disable auto-hinter. See also the note below.
+
+
+FT_LOAD_COLOR
+
+ This flag is used to request loading of color embedded-bitmap images. The 
+ resulting color bitmaps, if available, will have the FT_PIXEL_MODE_BGRA 
+ format. When the flag is not used and color bitmaps are found, they will be
+ converted to 256-level gray bitmaps transparently. Those bitmaps will be in
+ the FT_PIXEL_MODE_GRAY format.
 """
 
 FT_LOAD_FLAGS = { 'FT_LOAD_DEFAULT'                      : 0x0,
@@ -149,5 +158,6 @@ FT_LOAD_FLAGS = { 'FT_LOAD_DEFAULT'                      : 0x0,
                   'FT_LOAD_IGNORE_TRANSFORM'             : 0x800,
                   'FT_LOAD_MONOCHROME'                   : 0x1000,
                   'FT_LOAD_LINEAR_DESIGN'                : 0x2000,
-                  'FT_LOAD_NO_AUTOHINT'                  : 0x8000 }
+                  'FT_LOAD_NO_AUTOHINT'                  : 0x8000,
+                  'FT_LOAD_COLOR'                        : 0x100000 }
 globals().update(FT_LOAD_FLAGS)


### PR DESCRIPTION
FT_LOAD_COLOR was added to the ft_load_flags.py. When this flag is
given, freetype will return a bgra version of emoji chars instead of
grey scale.
Tested with "Apple Color Emoji.ttc".