### PR TITLE
Adding two new load flags, and their associated documentation from up…

### DIFF
--- a/freetype/ft_enums/ft_load_flags.py
+++ b/freetype/ft_enums/ft_load_flags.py
@@ -137,11 +137,28 @@ FT_LOAD_NO_AUTOHINT
 
 FT_LOAD_COLOR
 
- This flag is used to request loading of color embedded-bitmap images. The 
- resulting color bitmaps, if available, will have the FT_PIXEL_MODE_BGRA 
- format. When the flag is not used and color bitmaps are found, they will be
- converted to 256-level gray bitmaps transparently. Those bitmaps will be in
- the FT_PIXEL_MODE_GRAY format.
+  This flag is used to request loading of color embedded-bitmap images. The
+  resulting color bitmaps, if available, will have the FT_PIXEL_MODE_BGRA
+  format. When the flag is not used and color bitmaps are found, they will be
+  converted to 256-level gray bitmaps transparently. Those bitmaps will be in
+  the FT_PIXEL_MODE_GRAY format.
+
+
+FT_LOAD_COMPUTE_METRICS
+  Compute glyph metrics from the glyph data, without the use of bundled metrics
+  tables (for example, the `hdmx' table in TrueType fonts).  This flag is
+  mainly used by font validating or font editing applications, which need to
+  ignore, verify, or edit those tables.
+
+  Currently, this flag is only implemented for TrueType fonts.
+
+
+FT_LOAD_BITMAP_METRICS_ONLY
+  Request loading of the metrics and bitmap image information of a (possibly
+  embedded) bitmap glyph without allocating or copying the bitmap image data
+  itself.  No effect if the target glyph is not a bitmap image.
+
+  This flag unsets FT_LOAD_RENDER.
 """
 
 FT_LOAD_FLAGS = { 'FT_LOAD_DEFAULT'                      : 0x0,
@@ -159,5 +176,7 @@ FT_LOAD_FLAGS = { 'FT_LOAD_DEFAULT'                      : 0x0,
                   'FT_LOAD_MONOCHROME'                   : 0x1000,
                   'FT_LOAD_LINEAR_DESIGN'                : 0x2000,
                   'FT_LOAD_NO_AUTOHINT'                  : 0x8000,
-                  'FT_LOAD_COLOR'                        : 0x100000 }
+                  'FT_LOAD_COLOR'                        : 0x100000,
+                  'FT_LOAD_COMPUTE_METRICS'              : 0x200000,
+                  'FT_LOAD_BITMAP_METRICS_ONLY'          : 0x400000 }
 globals().update(FT_LOAD_FLAGS)

--- a/freetype/raw.py
+++ b/freetype/raw.py
@@ -126,3 +126,11 @@ FT_Stroker_Done             = _lib.FT_Stroker_Done
 FT_Glyph_Stroke             = _lib.FT_Glyph_Stroke
 FT_Glyph_StrokeBorder       = _lib.FT_Glyph_StrokeBorder
 FT_Glyph_To_Bitmap          = _lib.FT_Glyph_To_Bitmap
+
+
+# FT_Property_Get/FT_Property_Set requires FreeType 2.7.x+
+try:
+    FT_Property_Get    = _lib.FT_Property_Get
+    FT_Property_Set    = _lib.FT_Property_Set
+except AttributeError:
+    pass


### PR DESCRIPTION
…stream.

FT_LOAD_COMPUTE_METRICS was introduced upstream in FreeType 2.6.1 by me,
as part of the enhancement for the new Font Validator backend.

Also re-indent the previous's documentation, FT_LOAD_COLOR, like the rest.

Part of the fix to
https://github.com/rougier/freetype-py/issues/49