### PR TITLE
Adding symbols from 2.2.X onwards

### DIFF
--- a/examples/agg-trick.py
+++ b/examples/agg-trick.py
@@ -27,7 +27,10 @@ def render(filename = "Vera.ttf", hinting = (False,False), gamma = 1.5, lcd=Fals
     if lcd:
         flags |= FT_LOAD_TARGET_LCD
         Z = np.zeros( (H,W,3), dtype=np.ubyte )
-        set_lcd_filter( FT_LCD_FILTER_DEFAULT )
+        try:
+            set_lcd_filter( FT_LCD_FILTER_DEFAULT )
+        except:
+            pass
 
 
     for size in range(9,23):

--- a/examples/emoji-color.py
+++ b/examples/emoji-color.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 
 import freetype
 import numpy as np

--- a/examples/glyph-color.py
+++ b/examples/glyph-color.py
@@ -26,8 +26,8 @@ if __name__ == '__main__':
     glyph = slot.get_glyph()
     stroker = Stroker( )
     stroker.set(64, FT_STROKER_LINECAP_ROUND, FT_STROKER_LINEJOIN_ROUND, 0 )
-    glyph.stroke( stroker )
-    blyph = glyph.to_bitmap(FT_RENDER_MODE_NORMAL, Vector(0,0))
+    glyph.stroke( stroker , True )
+    blyph = glyph.to_bitmap(FT_RENDER_MODE_NORMAL, Vector(0,0), True )
     bitmap = blyph.bitmap
     width, rows, pitch = bitmap.width, bitmap.rows, bitmap.pitch
     top, left = blyph.top, blyph.left

--- a/examples/glyph-outline.py
+++ b/examples/glyph-outline.py
@@ -23,8 +23,8 @@ if __name__ == '__main__':
     glyph = slot.get_glyph()
     stroker = Stroker( )
     stroker.set(64, FT_STROKER_LINECAP_ROUND, FT_STROKER_LINEJOIN_ROUND, 0 )
-    glyph.stroke( stroker )
-    blyph = glyph.to_bitmap(FT_RENDER_MODE_NORMAL, Vector(0,0))
+    glyph.stroke( stroker , True )
+    blyph = glyph.to_bitmap(FT_RENDER_MODE_NORMAL, Vector(0,0), True )
     bitmap = blyph.bitmap
     width, rows, pitch = bitmap.width, bitmap.rows, bitmap.pitch
     top, left = blyph.top, blyph.left

--- a/examples/texture_font.py
+++ b/examples/texture_font.py
@@ -261,7 +261,10 @@ class TextureFont:
         self.height    = metrics.height/64.0
         self.linegap   = self.height - self.ascender + self.descender
         self.depth = atlas.depth
-        set_lcd_filter(FT_LCD_FILTER_LIGHT)
+        try:
+            set_lcd_filter(FT_LCD_FILTER_LIGHT)
+        except:
+            pass
 
 
     def __getitem__(self, charcode):

--- a/freetype/__init__.py
+++ b/freetype/__init__.py
@@ -712,6 +712,9 @@ class Glyph( object ):
                        before rendering. Can be 0 (if no translation). The origin is
                        expressed in 26.6 pixels.
 
+                       We also detect a plain vector and make a pointer out of it,
+                       if that's the case.
+
         :param destroy: A boolean that indicates that the original glyph image
                         should be destroyed by this function. It is never destroyed
                         in case of error.
@@ -727,8 +730,13 @@ class Glyph( object ):
           replaced by this function (with newly allocated data). Typically, you
           would use (omitting error handling):
         '''
-        error = FT_Glyph_To_Bitmap( byref(self._FT_Glyph),
-                                    mode, origin, destroy)
+        if ( type(origin) == FT_Vector ):
+            error = FT_Glyph_To_Bitmap( byref(self._FT_Glyph),
+                                        mode, byref(origin), destroy )
+        else:
+            error = FT_Glyph_To_Bitmap( byref(self._FT_Glyph),
+                                        mode, origin, destroy )
+
         if error: raise FT_Exception( error )
         return BitmapGlyph( self._FT_Glyph )
 

--- a/freetype/__init__.py
+++ b/freetype/__init__.py
@@ -1291,8 +1291,16 @@ class Face( object ):
           This function simply calls FT_Get_Char_Index and FT_Load_Glyph.
         '''
 
-        if len(char) == 1:
+        # python 2 with ascii input
+        if ( isinstance(char, str) and ( len(char) == 1 ) ):
             char = ord(char)
+        # python 2 with utf8 string input
+        if ( isinstance(char, str) and ( len(char) != 1 ) ):
+            char = ord(char.decode('utf8'))
+        # python 3 or python 2 with __future__.unicode_literals
+        if ( isinstance(char, unicode) and ( len(char) == 1 ) ):
+            char = ord(char)
+        # allow bare integer to pass through
         error = FT_Load_Char( self._FT_Face, char, flags )
         if error: raise FT_Exception( error )
 

--- a/freetype/raw.py
+++ b/freetype/raw.py
@@ -84,7 +84,11 @@ FT_Select_Charmap      = _lib.FT_Select_Charmap
 FT_Set_Charmap         = _lib.FT_Set_Charmap
 FT_Get_Charmap_Index   = _lib.FT_Get_Charmap_Index
 FT_Get_CMap_Language_ID= _lib.FT_Get_CMap_Language_ID
-FT_Get_CMap_Format     = _lib.FT_Get_CMap_Format
+try:
+    #introduced between 2.2.x and 2.3.x
+    FT_Get_CMap_Format     = _lib.FT_Get_CMap_Format
+except AttributeError:
+    pass
 FT_Get_Char_Index      = _lib.FT_Get_Char_Index
 FT_Get_First_Char      = _lib.FT_Get_First_Char
 FT_Get_Next_Char       = _lib.FT_Get_Next_Char
@@ -102,7 +106,11 @@ FT_Get_X11_Font_Format.restype = c_char_p
 
 FT_Get_Sfnt_Name_Count = _lib.FT_Get_Sfnt_Name_Count
 FT_Get_Sfnt_Name       = _lib.FT_Get_Sfnt_Name
-FT_Get_Advance         = _lib.FT_Get_Advance
+try:
+    # introduced between 2.2.x and 2.3.x
+    FT_Get_Advance         = _lib.FT_Get_Advance
+except AttributeError:
+    pass
 
 
 FT_Outline_GetInsideBorder  = _lib.FT_Outline_GetInsideBorder
@@ -134,3 +142,114 @@ try:
     FT_Property_Set    = _lib.FT_Property_Set
 except AttributeError:
     pass
+
+
+# Wholesale import of 102 routines which can be reasonably expected
+# to be found in freetype 2.2.x onwards. Some of these might need
+# to be protected with try:/except AttributeError: in some freetype builds.
+
+FTC_CMapCache_Lookup           = _lib.FTC_CMapCache_Lookup
+FTC_CMapCache_New              = _lib.FTC_CMapCache_New
+FTC_ImageCache_Lookup          = _lib.FTC_ImageCache_Lookup
+FTC_ImageCache_New             = _lib.FTC_ImageCache_New
+FTC_Manager_Done               = _lib.FTC_Manager_Done
+FTC_Manager_LookupFace         = _lib.FTC_Manager_LookupFace
+FTC_Manager_LookupSize         = _lib.FTC_Manager_LookupSize
+FTC_Manager_New                = _lib.FTC_Manager_New
+FTC_Manager_RemoveFaceID       = _lib.FTC_Manager_RemoveFaceID
+FTC_Manager_Reset              = _lib.FTC_Manager_Reset
+FTC_Node_Unref                 = _lib.FTC_Node_Unref
+FTC_SBitCache_Lookup           = _lib.FTC_SBitCache_Lookup
+FTC_SBitCache_New              = _lib.FTC_SBitCache_New
+
+FT_Activate_Size               = _lib.FT_Activate_Size
+FT_Add_Default_Modules         = _lib.FT_Add_Default_Modules
+FT_Add_Module                  = _lib.FT_Add_Module
+FT_Angle_Diff                  = _lib.FT_Angle_Diff
+FT_Atan2                       = _lib.FT_Atan2
+FT_Bitmap_Convert              = _lib.FT_Bitmap_Convert
+FT_Bitmap_Copy                 = _lib.FT_Bitmap_Copy
+FT_Bitmap_Done                 = _lib.FT_Bitmap_Done
+FT_Bitmap_Embolden             = _lib.FT_Bitmap_Embolden
+FT_Bitmap_New                  = _lib.FT_Bitmap_New
+FT_CeilFix                     = _lib.FT_CeilFix
+FT_ClassicKern_Free            = _lib.FT_ClassicKern_Free
+FT_ClassicKern_Validate        = _lib.FT_ClassicKern_Validate
+FT_Cos                         = _lib.FT_Cos
+FT_DivFix                      = _lib.FT_DivFix
+FT_Done_Library                = _lib.FT_Done_Library
+FT_Done_Size                   = _lib.FT_Done_Size
+FT_FloorFix                    = _lib.FT_FloorFix
+FT_Get_BDF_Charset_ID          = _lib.FT_Get_BDF_Charset_ID
+FT_Get_BDF_Property            = _lib.FT_Get_BDF_Property
+FT_Get_MM_Var                  = _lib.FT_Get_MM_Var
+FT_Get_Module                  = _lib.FT_Get_Module
+FT_Get_Multi_Master            = _lib.FT_Get_Multi_Master
+FT_Get_PFR_Advance             = _lib.FT_Get_PFR_Advance
+FT_Get_PFR_Kerning             = _lib.FT_Get_PFR_Kerning
+FT_Get_PFR_Metrics             = _lib.FT_Get_PFR_Metrics
+FT_Get_PS_Font_Info            = _lib.FT_Get_PS_Font_Info
+FT_Get_PS_Font_Private         = _lib.FT_Get_PS_Font_Private
+FT_Get_Renderer                = _lib.FT_Get_Renderer
+FT_Get_Sfnt_Table              = _lib.FT_Get_Sfnt_Table
+FT_Get_TrueType_Engine_Type    = _lib.FT_Get_TrueType_Engine_Type
+FT_Get_WinFNT_Header           = _lib.FT_Get_WinFNT_Header
+FT_Glyph_Copy                  = _lib.FT_Glyph_Copy
+FT_GlyphSlot_Embolden          = _lib.FT_GlyphSlot_Embolden
+FT_GlyphSlot_Oblique           = _lib.FT_GlyphSlot_Oblique
+FT_GlyphSlot_Own_Bitmap        = _lib.FT_GlyphSlot_Own_Bitmap
+FT_Glyph_Transform             = _lib.FT_Glyph_Transform
+FT_Has_PS_Glyph_Names          = _lib.FT_Has_PS_Glyph_Names
+FT_List_Add                    = _lib.FT_List_Add
+FT_List_Finalize               = _lib.FT_List_Finalize
+FT_List_Find                   = _lib.FT_List_Find
+FT_List_Insert                 = _lib.FT_List_Insert
+FT_List_Iterate                = _lib.FT_List_Iterate
+FT_List_Remove                 = _lib.FT_List_Remove
+FT_List_Up                     = _lib.FT_List_Up
+FT_Load_Sfnt_Table             = _lib.FT_Load_Sfnt_Table
+FT_Matrix_Invert               = _lib.FT_Matrix_Invert
+FT_Matrix_Multiply             = _lib.FT_Matrix_Multiply
+FT_MulDiv                      = _lib.FT_MulDiv
+FT_MulFix                      = _lib.FT_MulFix
+FT_New_Library                 = _lib.FT_New_Library
+FT_New_Size                    = _lib.FT_New_Size
+FT_OpenType_Free               = _lib.FT_OpenType_Free
+FT_OpenType_Validate           = _lib.FT_OpenType_Validate
+FT_Outline_Check               = _lib.FT_Outline_Check
+FT_Outline_Copy                = _lib.FT_Outline_Copy
+FT_Outline_Decompose           = _lib.FT_Outline_Decompose
+FT_Outline_Done                = _lib.FT_Outline_Done
+FT_Outline_Done_Internal       = _lib.FT_Outline_Done_Internal
+FT_Outline_Embolden            = _lib.FT_Outline_Embolden
+FT_Outline_Get_Bitmap          = _lib.FT_Outline_Get_Bitmap
+FT_Outline_Get_Orientation     = _lib.FT_Outline_Get_Orientation
+FT_Outline_New                 = _lib.FT_Outline_New
+FT_Outline_New_Internal        = _lib.FT_Outline_New_Internal
+FT_Outline_Render              = _lib.FT_Outline_Render
+FT_Outline_Reverse             = _lib.FT_Outline_Reverse
+FT_Outline_Transform           = _lib.FT_Outline_Transform
+FT_Outline_Translate           = _lib.FT_Outline_Translate
+FT_Remove_Module               = _lib.FT_Remove_Module
+FT_RoundFix                    = _lib.FT_RoundFix
+FT_Set_Debug_Hook              = _lib.FT_Set_Debug_Hook
+FT_Set_MM_Blend_Coordinates    = _lib.FT_Set_MM_Blend_Coordinates
+FT_Set_MM_Design_Coordinates   = _lib.FT_Set_MM_Design_Coordinates
+FT_Set_Renderer                = _lib.FT_Set_Renderer
+FT_Set_Var_Blend_Coordinates   = _lib.FT_Set_Var_Blend_Coordinates
+FT_Set_Var_Design_Coordinates  = _lib.FT_Set_Var_Design_Coordinates
+FT_Sfnt_Table_Info             = _lib.FT_Sfnt_Table_Info
+FT_Sin                         = _lib.FT_Sin
+FT_Stream_OpenGzip             = _lib.FT_Stream_OpenGzip
+FT_Stream_OpenLZW              = _lib.FT_Stream_OpenLZW
+FT_Tan                         = _lib.FT_Tan
+FT_TrueTypeGX_Free             = _lib.FT_TrueTypeGX_Free
+FT_TrueTypeGX_Validate         = _lib.FT_TrueTypeGX_Validate
+FT_Vector_From_Polar           = _lib.FT_Vector_From_Polar
+FT_Vector_Length               = _lib.FT_Vector_Length
+FT_Vector_Polarize             = _lib.FT_Vector_Polarize
+FT_Vector_Rotate               = _lib.FT_Vector_Rotate
+FT_Vector_Transform            = _lib.FT_Vector_Transform
+FT_Vector_Unit                 = _lib.FT_Vector_Unit
+
+# Wholesale import ends

--- a/freetype/raw.py
+++ b/freetype/raw.py
@@ -59,7 +59,7 @@ FT_Attach_Stream       = _lib.FT_Attach_Stream
 try:
     FT_Reference_Face      = _lib.FT_Reference_Face
 except AttributeError:
-	pass
+    pass
 
 FT_Done_Face           = _lib.FT_Done_Face
 FT_Done_Glyph          = _lib.FT_Done_Glyph
@@ -99,7 +99,7 @@ try:
     FT_Get_FSType_Flags    = _lib.FT_Get_FSType_Flags
     FT_Get_FSType_Flags.restype  = c_ushort
 except AttributeError:
-	pass
+    pass
 
 FT_Get_X11_Font_Format = _lib.FT_Get_X11_Font_Format
 FT_Get_X11_Font_Format.restype = c_char_p

--- a/freetype/raw.py
+++ b/freetype/raw.py
@@ -143,6 +143,13 @@ try:
 except AttributeError:
     pass
 
+# These two are only found when TT debugger is enabled
+try:
+    TT_New_Context     = _lib.TT_New_Context
+    TT_RunIns          = _lib.TT_RunIns
+except AttributeError:
+    pass
+
 
 # Wholesale import of 102 routines which can be reasonably expected
 # to be found in freetype 2.2.x onwards. Some of these might need


### PR DESCRIPTION
This is taken from fedora's build farm, so it is possible that other freetype builds have fewer symbols... However, 2.2.X is more than a decade old!