### PR TITLE
pycairo based rewrite of the drawing examples.

### DIFF
--- a/examples/bitmap_to_surface.py
+++ b/examples/bitmap_to_surface.py
@@ -14,6 +14,8 @@ Usage:
 
 Works with cairocffi too. (Replace "from cairo ..." with "from cairocffi ...")
 
+Limitation: Surface.create_for_data is not in the "python 3, pycairo < 1.11" combo.
+
 This is a heavily modified copy of a few routines from Lawrence D'Oliveiro[1],
 adjusted for freetype-py, and bugfix/workaround for mono-rendering [2].
 

--- a/examples/bitmap_to_surface.py
+++ b/examples/bitmap_to_surface.py
@@ -1,0 +1,93 @@
+'''
+FT_Bitmap to CAIRO_SURFACE_TYPE_IMAGE module
+============================================
+
+Converting from Freetype's FT_Bitmap to Cairo's CAIRO_SURFACE_TYPE_IMAGE
+
+Copyright 2017 Hin-Tak Leung
+
+FreeType is under FTL (BSD license with an advertising clause) or GPLv2+.
+Cairo is under LGPLv2 or MPLv1.1.
+
+Usage:
+     from bitmap_to_surface import make_image_surface
+
+Works with cairocffi too. (Replace "from cairo ..." with "from cairocffi ...")
+
+This is a heavily modified copy of a few routines from Lawrence D'Oliveiro[1],
+adjusted for freetype-py, and bugfix/workaround for mono-rendering [2].
+
+The bugfix/workaround requires libtiff on small-endian platforms.
+
+TODO: Look into using FreeType's FT_Bitmap_Convert() instead. However, libtiff
+      is common enough, and probably not important.
+
+[1] https://github.com/ldo/python_freetype
+    https://github.com/ldo/python_freetype_examples
+
+[2] https://github.com/ldo/python_freetype/issues/1
+    https://github.com/ldo/python_freetype_examples/issues/1
+'''
+from freetype import FT_PIXEL_MODE_MONO, FT_PIXEL_MODE_GRAY, FT_Pointer, FT_Bitmap
+
+from cairo import ImageSurface, FORMAT_A1, FORMAT_A8
+#from cairocffi import ImageSurface, FORMAT_A1, FORMAT_A8
+
+from array import array
+from ctypes import cast, memmove, CDLL, c_void_p, c_int
+from sys import byteorder
+
+def make_image_surface(bitmap, copy = True) :
+    if ( type(bitmap) == FT_Bitmap ):
+        # bare FT_Bitmap
+        content = bitmap
+    else:
+        # wrapped Bitmap instance
+        content = bitmap._FT_Bitmap
+    "creates a Cairo ImageSurface containing (a copy of) the Bitmap pixels."
+    if content.pixel_mode == FT_PIXEL_MODE_MONO :
+        cairo_format = FORMAT_A1
+    elif content.pixel_mode == FT_PIXEL_MODE_GRAY :
+        cairo_format = FORMAT_A8
+    else :
+        raise NotImplementedError("unsupported bitmap format %d" % content.pixel_mode)
+    src_pitch = content.pitch
+    dst_pitch = ImageSurface.format_stride_for_width(cairo_format, content.width)
+    if not copy and dst_pitch == src_pitch and content.buffer != None :
+        pixels = content.buffer
+    else :
+        pixels = to_array(content, content.pixel_mode, dst_pitch)
+    result =  ImageSurface.create_for_data(
+        pixels, cairo_format,
+        content.width, content.rows,
+        dst_pitch)
+    return result
+
+def to_array(content, pixel_mode, dst_pitch = None) :
+    "returns a Python array object containing a copy of the Bitmap pixels."
+    if dst_pitch == None :
+        dst_pitch = content.pitch
+    buffer_size = content.rows * dst_pitch
+    buffer = array("B", b"0" * buffer_size)
+    dstaddr = buffer.buffer_info()[0]
+    srcaddr = cast(content.buffer, FT_Pointer).value
+    src_pitch = content.pitch
+    if dst_pitch == src_pitch :
+        memmove(dstaddr, srcaddr, buffer_size)
+    else :
+        # have to copy a row at a time
+        if src_pitch < 0 or dst_pitch < 0 :
+            raise NotImplementedError("can't cope with negative bitmap pitch")
+        assert dst_pitch > src_pitch
+        for i in range(content.rows) :
+            memmove(dstaddr, srcaddr, src_pitch)
+            dstaddr += dst_pitch
+            srcaddr += src_pitch
+    # pillow/PIL itself requires libtiff so it is assumed to be around.
+    # swap the bit-order from freetype's (MSB) to cairo's (host order) if needed
+    if ( ( byteorder == 'little' ) and (pixel_mode == FT_PIXEL_MODE_MONO ) ):
+        libtiff = CDLL("libtiff.so.5")
+        libtiff.TIFFReverseBits.restype = None
+        libtiff.TIFFReverseBits.argtypes = (c_void_p, c_int)
+        libtiff.TIFFReverseBits(buffer.buffer_info()[0], buffer_size)
+    return buffer

--- a/examples/bitmap_to_surface.py
+++ b/examples/bitmap_to_surface.py
@@ -1,13 +1,30 @@
+# FT_Bitmap to CAIRO_SURFACE_TYPE_IMAGE module
+# ============================================
+#
+# Copyright 2017 Hin-Tak Leung
+#
+# FreeType is under FTL (BSD license with an advertising clause) or GPLv2+.
+# Cairo is under LGPLv2 or MPLv1.1.
+#
+# This is a heavily modified copy of a few routines from Lawrence D'Oliveiro[1],
+# adjusted for freetype-py, and bugfix/workaround for mono-rendering [2].
+#
+# The bugfix/workaround requires libtiff on small-endian platforms.
+#
+# TODO: Look into using FreeType's FT_Bitmap_Convert() instead. However, libtiff
+#      is common enough, and probably not important.
+#
+#[1] https://github.com/ldo/python_freetype
+#    https://github.com/ldo/python_freetype_examples
+#
+#[2] https://github.com/ldo/python_freetype/issues/1
+#    https://github.com/ldo/python_freetype_examples/issues/1
+#
 '''
 FT_Bitmap to CAIRO_SURFACE_TYPE_IMAGE module
 ============================================
 
 Converting from Freetype's FT_Bitmap to Cairo's CAIRO_SURFACE_TYPE_IMAGE
-
-Copyright 2017 Hin-Tak Leung
-
-FreeType is under FTL (BSD license with an advertising clause) or GPLv2+.
-Cairo is under LGPLv2 or MPLv1.1.
 
 Usage:
      from bitmap_to_surface import make_image_surface
@@ -15,20 +32,6 @@ Usage:
 Works with cairocffi too. (Replace "from cairo ..." with "from cairocffi ...")
 
 Limitation: Surface.create_for_data is not in the "python 3, pycairo < 1.11" combo.
-
-This is a heavily modified copy of a few routines from Lawrence D'Oliveiro[1],
-adjusted for freetype-py, and bugfix/workaround for mono-rendering [2].
-
-The bugfix/workaround requires libtiff on small-endian platforms.
-
-TODO: Look into using FreeType's FT_Bitmap_Convert() instead. However, libtiff
-      is common enough, and probably not important.
-
-[1] https://github.com/ldo/python_freetype
-    https://github.com/ldo/python_freetype_examples
-
-[2] https://github.com/ldo/python_freetype/issues/1
-    https://github.com/ldo/python_freetype_examples/issues/1
 '''
 from freetype import FT_PIXEL_MODE_MONO, FT_PIXEL_MODE_GRAY, FT_Pointer, FT_Bitmap
 

--- a/examples/emoji-color-cairo.py
+++ b/examples/emoji-color-cairo.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+#  pycairo/cairocffi-based emoji-color example - Copyright 2017 Hin-Tak Leung
+#  Distributed under the terms of the new BSD license.
+#
+#  This script demonstrates overlapping emojis.
+#
+
+import freetype
+import numpy as np
+from PIL import Image
+
+from cairo import ImageSurface, FORMAT_ARGB32, Context
+
+face = freetype.Face("Apple Color Emoji.ttf")
+face.set_char_size( 160*64 )
+face.load_char('😀', freetype.FT_LOAD_COLOR)
+
+bitmap = face.glyph.bitmap
+width = face.glyph.bitmap.width
+rows = face.glyph.bitmap.rows
+bitmap = np.array(bitmap.buffer, dtype=np.uint8).reshape((bitmap.rows,bitmap.width,4))
+
+I = ImageSurface(FORMAT_ARGB32, width, rows)
+ndI = np.ndarray(shape=(rows,width), buffer=I.get_data(),
+                 dtype=np.uint32, order='C',
+                 strides=[I.get_stride(), 4])
+
+# Although both are 32-bit, cairo is host-order while
+# freetype is small endian.
+ndI[:,:] = bitmap[:,:,3] * 16777216 + bitmap[:,:,2] * 65536 + bitmap[:,:,1] * 256 + bitmap[:,:,0]
+I.mark_dirty()
+
+surface = ImageSurface(FORMAT_ARGB32, 2*width, rows)
+ctx = Context(surface)
+
+ctx.set_source_surface(I, 0, 0)
+ctx.paint()
+
+ctx.set_source_surface(I, width/2, 0)
+ctx.paint()
+
+ctx.set_source_surface(I, width , 0)
+ctx.paint()
+
+surface.write_to_png("emoji-color-cairo.png")
+Image.open("emoji-color-cairo.png").show()

--- a/examples/emoji-color-cairo.py
+++ b/examples/emoji-color-cairo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 #  pycairo/cairocffi-based emoji-color example - Copyright 2017 Hin-Tak Leung

--- a/examples/emoji-color-cairo.py
+++ b/examples/emoji-color-cairo.py
@@ -31,9 +31,12 @@ if ( face.glyph.bitmap.pitch != width * 4 ):
 bitmap = np.array(bitmap.buffer, dtype=np.uint8).reshape((bitmap.rows,bitmap.width,4))
 
 I = ImageSurface(FORMAT_ARGB32, width, rows)
-ndI = np.ndarray(shape=(rows,width), buffer=I.get_data(),
-                 dtype=np.uint32, order='C',
-                 strides=[I.get_stride(), 4])
+try:
+    ndI = np.ndarray(shape=(rows,width), buffer=I.get_data(),
+                     dtype=np.uint32, order='C',
+                     strides=[I.get_stride(), 4])
+except NotImplementedError:
+    raise SystemExit("For python 3.x, you need pycairo >= 1.11+ (from https://github.com/pygobject/pycairo)")
 
 # Although both are 32-bit, cairo is host-order while
 # freetype is small endian.

--- a/examples/emoji-color-cairo.py
+++ b/examples/emoji-color-cairo.py
@@ -8,6 +8,8 @@
 #
 #  Note: On Mac OS X before Sierra (10.12), change ttc->ttf;
 #        try Google's NotoColorEmoji.ttf at size 109 on Linux.
+#
+#  Limitation: Suface.get_data() is not in the "python 3, pycairo < 1.11" combo.
 
 import freetype
 import numpy as np

--- a/examples/emoji-color-cairo.py
+++ b/examples/emoji-color-cairo.py
@@ -6,6 +6,8 @@
 #
 #  This script demonstrates overlapping emojis.
 #
+#  Note: On Mac OS X before Sierra (10.12), change ttc->ttf;
+#        try Google's NotoColorEmoji.ttf at size 109 on Linux.
 
 import freetype
 import numpy as np
@@ -13,7 +15,7 @@ from PIL import Image
 
 from cairo import ImageSurface, FORMAT_ARGB32, Context
 
-face = freetype.Face("Apple Color Emoji.ttf")
+face = freetype.Face("/System/Library/Fonts/Apple Color Emoji.ttc")
 # Not all char sizes are valid for emoji fonts;
 # Google's NotoColorEmoji only accept size 109 to get 136x128 bitmaps
 face.set_char_size( 160*64 )

--- a/examples/emoji-color-cairo.py
+++ b/examples/emoji-color-cairo.py
@@ -20,6 +20,10 @@ face.load_char('😀', freetype.FT_LOAD_COLOR)
 bitmap = face.glyph.bitmap
 width = face.glyph.bitmap.width
 rows = face.glyph.bitmap.rows
+
+# The line below depends on this assumption. Check.
+if ( face.glyph.bitmap.pitch != width * 4 ):
+    raise RuntimeError('pitch != width * 4 for color bitmap: Please report this.')
 bitmap = np.array(bitmap.buffer, dtype=np.uint8).reshape((bitmap.rows,bitmap.width,4))
 
 I = ImageSurface(FORMAT_ARGB32, width, rows)

--- a/examples/emoji-color-cairo.py
+++ b/examples/emoji-color-cairo.py
@@ -14,6 +14,8 @@ from PIL import Image
 from cairo import ImageSurface, FORMAT_ARGB32, Context
 
 face = freetype.Face("Apple Color Emoji.ttf")
+# Not all char sizes are valid for emoji fonts;
+# Google's NotoColorEmoji only accept size 109 to get 136x128 bitmaps
 face.set_char_size( 160*64 )
 face.load_char('😀', freetype.FT_LOAD_COLOR)
 

--- a/examples/emoji-color-cairo.py
+++ b/examples/emoji-color-cairo.py
@@ -35,7 +35,7 @@ ndI = np.ndarray(shape=(rows,width), buffer=I.get_data(),
 
 # Although both are 32-bit, cairo is host-order while
 # freetype is small endian.
-ndI[:,:] = bitmap[:,:,3] * 16777216 + bitmap[:,:,2] * 65536 + bitmap[:,:,1] * 256 + bitmap[:,:,0]
+ndI[:,:] = bitmap[:,:,3] * 2**24 + bitmap[:,:,2] * 2**16 + bitmap[:,:,1] * 2**8 + bitmap[:,:,0]
 I.mark_dirty()
 
 surface = ImageSurface(FORMAT_ARGB32, 2*width, rows)

--- a/examples/example_1-cairo.py
+++ b/examples/example_1-cairo.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+#
+#  pycairo/cairocffi-based FreeType example - Copyright 2017 Hin-Tak Leung
+#  Distributed under the terms of the new BSD license.
+#
+#  rewrite of the numply,matplotlib-based example from Nicolas P. Rougier
+#
+# -----------------------------------------------------------------------------
+#
+# Direct translation of example 1 from the freetype tutorial:
+# http://www.freetype.org/freetype2/docs/tutorial/step1.html
+#
+# Except we uses FreeType's own trigonometric functions instead of those
+# from the system/python's math library.
+
+
+from cairo import Context, ImageSurface, FORMAT_A8
+from bitmap_to_surface import make_image_surface
+
+from freetype.raw import *
+from PIL import Image
+
+WIDTH, HEIGHT = 640, 480
+image = ImageSurface(FORMAT_A8, WIDTH, HEIGHT)
+ctx = Context(image)
+
+def to_c_str(text):
+    ''' Convert python strings to null terminated c strings. '''
+    cStr = create_string_buffer(text.encode(encoding='UTF-8'))
+    return cast(pointer(cStr), POINTER(c_char))
+
+def draw_bitmap( bitmap, x, y):
+    global image, ctx
+    # cairo does not like zero-width surface
+    if (bitmap.width > 0):
+        glyph_surface = make_image_surface(bitmap)
+        ctx.set_source_surface(glyph_surface, x, y)
+        ctx.paint()
+
+def main():
+
+    library = FT_Library()
+    matrix  = FT_Matrix()
+    face    = FT_Face()
+    pen     = FT_Vector()
+    filename= 'Vera.ttf'
+    text    = 'Hello World !'
+    num_chars = len(text)
+    # FT_Angle is a 16.16 fixed-point value expressed in degrees.
+    angle   = FT_Angle(25 * 65536)
+
+    # initialize library, error handling omitted
+    error = FT_Init_FreeType( byref(library) )
+
+    # create face object, error handling omitted
+    error = FT_New_Face( library, to_c_str(filename), 0, byref(face) )
+
+
+    # set character size: 50pt at 100dpi, error handling omitted
+    error = FT_Set_Char_Size( face, 50 * 64, 0, 100, 0 )
+    slot = face.contents.glyph
+
+    # set up matrix
+    matrix.xx = FT_Cos( angle )
+    matrix.xy = - FT_Sin( angle )
+    matrix.yx = FT_Sin( angle )
+    matrix.yy = FT_Cos( angle )
+
+    # the pen position in 26.6 cartesian space coordinates; */
+    # start at (300,200) relative to the upper left corner  */
+    pen.x = 200 * 64;
+    pen.y = ( HEIGHT - 300 ) * 64
+
+    for n in range(num_chars):
+        # set transformation
+        FT_Set_Transform( face, byref(matrix), byref(pen) )
+
+        # load glyph image into the slot (erase previous one)
+        charcode = ord(text[n])
+        index = FT_Get_Char_Index( face, charcode )
+        FT_Load_Glyph( face, index, FT_LOAD_RENDER )
+
+        # now, draw to our target surface (convert position)
+        draw_bitmap( slot.contents.bitmap,
+                     slot.contents.bitmap_left,
+                     HEIGHT - slot.contents.bitmap_top )
+
+        # increment pen position
+        pen.x += slot.contents.advance.x
+        pen.y += slot.contents.advance.y
+
+    FT_Done_Face(face)
+    FT_Done_FreeType(library)
+
+    image.flush()
+    image.write_to_png("example_1-cairo.png")
+    Image.open("example_1-cairo.png").show()
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/glyph-color-cairo.py
+++ b/examples/glyph-color-cairo.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+#
+#  pycairo/cairocffi-based glyph-color example - Copyright 2017 Hin-Tak Leung
+#  Distributed under the terms of the new BSD license.
+#
+#  rewrite of the numply,matplotlib-based example from Nicolas P. Rougier
+#  - The two side-glyphs are positioned only roughly equivalently.
+#
+# -----------------------------------------------------------------------------
+'''
+Glyph colored rendering (with outline)
+'''
+from freetype import *
+
+# using Matrix class from Cairo, instead of FreeType's
+from cairo import Context, ImageSurface, FORMAT_ARGB32, SurfacePattern, FILTER_BEST, Matrix
+from bitmap_to_surface import make_image_surface
+
+if __name__ == '__main__':
+    from PIL import Image
+
+    face = Face('./Vera.ttf')
+    face.set_char_size( 96*64 )
+
+    # Outline
+    flags = FT_LOAD_DEFAULT | FT_LOAD_NO_BITMAP
+    face.load_char('S', flags )
+    slot = face.glyph
+    glyph = slot.get_glyph()
+    stroker = Stroker( )
+    stroker.set(64, FT_STROKER_LINECAP_ROUND, FT_STROKER_LINEJOIN_ROUND, 0 )
+    glyph.stroke( stroker , True )
+    del stroker
+    blyph = glyph.to_bitmap(FT_RENDER_MODE_NORMAL, Vector(0,0), True )
+    bitmap = blyph.bitmap
+    widthZ, rowsZ, pitch = bitmap.width, bitmap.rows, bitmap.pitch
+    Z = make_image_surface(bitmap)
+
+    # Plain
+    flags = FT_LOAD_RENDER
+    face.load_char('S', flags)
+    bitmap = face.glyph.bitmap
+    widthF, rowsF, pitch = bitmap.width, bitmap.rows, bitmap.pitch
+    F = make_image_surface(bitmap)
+
+    # Draw
+    surface = ImageSurface(FORMAT_ARGB32, 1200, 500)
+    ctx = Context(surface)
+
+    # fill background as gray
+    ctx.rectangle(0,0,1200,500)
+    ctx.set_source_rgb (0.5 , 0.5, 0.5)
+    ctx.fill()
+
+    # use the stroked font's size as scale, as it is likely slightly larger
+    scale = 400.0 / rowsZ
+
+    # draw bitmap first
+    ctx.set_source_surface(F, 0, 0)
+    patternF = ctx.get_source()
+    SurfacePattern.set_filter(patternF, FILTER_BEST)
+
+    scalematrix = Matrix()
+    scalematrix.scale(1.0/scale,1.0/scale)
+    scalematrix.translate(-(600.0 - widthF *scale /2.0 ), -50)
+    patternF.set_matrix(scalematrix)
+    ctx.set_source_rgb (1 , 1, 0)
+    ctx.mask(patternF)
+    ctx.fill()
+
+    scalematrix.translate(+400,0)
+    patternF.set_matrix(scalematrix)
+    ctx.mask(patternF)
+    ctx.fill()
+
+    # stroke on top
+    ctx.set_source_surface(Z, 0, 0)
+    patternZ = ctx.get_source()
+    SurfacePattern.set_filter(patternZ, FILTER_BEST)
+
+    scalematrix = Matrix()
+    scalematrix.scale(1.0/scale,1.0/scale)
+    scalematrix.translate(-(600.0 - widthZ *scale /2.0 ), -50)
+    patternZ.set_matrix(scalematrix)
+    ctx.set_source_rgb (1 , 0, 0)
+    ctx.mask(patternZ)
+    ctx.fill()
+
+    scalematrix.translate(-400,0)
+    patternZ.set_matrix(scalematrix)
+    ctx.mask(patternZ)
+    ctx.fill()
+
+    surface.flush()
+    surface.write_to_png("glyph-color-cairo.png")
+    Image.open("glyph-color-cairo.png").show()

--- a/examples/glyph-lcd-cairo.py
+++ b/examples/glyph-lcd-cairo.py
@@ -51,7 +51,8 @@ if __name__ == '__main__':
     ndI = ndarray(shape=(rows,width), buffer=I.get_data(),
                   dtype=uint32, order='C',
                   strides=[I.get_stride(), 4])
-    ndI[:,:] = 4278190080 + ndR[:,:] * 65536 + ndG[:,:] * 256 + ndB[:,:]
+    # 255 * 2**24 = opaque
+    ndI[:,:] = 255 * 2**24 + ndR[:,:] * 2**16 + ndG[:,:] * 2**8 + ndB[:,:]
     I.mark_dirty()
 
     surface = ImageSurface(FORMAT_ARGB32, 800, 600)
@@ -97,7 +98,8 @@ if __name__ == '__main__':
     ndI = ndarray(shape=(rows,width), buffer=I.get_data(),
                   dtype=uint32, order='C',
                   strides=[I.get_stride(), 4])
-    ndI[:,:] = 4278190080 + ndR[:,:] * 65536 + ndG[:,:] * 256 + ndB[:,:]
+    # 255 * 2**24 = opaque
+    ndI[:,:] = 255 * 2**24 + ndR[:,:] * 2**16 + ndG[:,:] * 2**8 + ndB[:,:]
     I.mark_dirty()
 
     ctx.set_source_surface(I, 0, 0)

--- a/examples/glyph-lcd-cairo.py
+++ b/examples/glyph-lcd-cairo.py
@@ -31,20 +31,20 @@ if __name__ == '__main__':
     width  = face.glyph.bitmap.width//3
     rows   = face.glyph.bitmap.rows
     pitch  = face.glyph.bitmap.pitch
-    whole_thing = (c_ubyte * (pitch * rows))()
-    memmove(pointer(whole_thing), bitmap._FT_Bitmap.buffer,
+    copybuffer = (c_ubyte * (pitch * rows))()
+    memmove(pointer(copybuffer), bitmap._FT_Bitmap.buffer,
             pitch * rows)
 
     I = ImageSurface(FORMAT_ARGB32, width, rows)
-    ndR = ndarray(shape=(rows,width), buffer=whole_thing,
+    ndR = ndarray(shape=(rows,width), buffer=copybuffer,
                   dtype=ubyte, order='C',
                   offset=0,
                   strides=[pitch, 3])
-    ndG = ndarray(shape=(rows,width), buffer=whole_thing,
+    ndG = ndarray(shape=(rows,width), buffer=copybuffer,
                   dtype=ubyte, order='C',
                   offset=1,
                   strides=[pitch, 3])
-    ndB = ndarray(shape=(rows,width), buffer=whole_thing,
+    ndB = ndarray(shape=(rows,width), buffer=copybuffer,
                   dtype=ubyte, order='C',
                   offset=2,
                   strides=[pitch, 3])
@@ -77,20 +77,20 @@ if __name__ == '__main__':
     width  = face.glyph.bitmap.width
     rows   = face.glyph.bitmap.rows//3
     pitch  = face.glyph.bitmap.pitch
-    whole_thing = (c_ubyte * (pitch * face.glyph.bitmap.rows))()
-    memmove(pointer(whole_thing), bitmap._FT_Bitmap.buffer,
+    copybuffer = (c_ubyte * (pitch * face.glyph.bitmap.rows))()
+    memmove(pointer(copybuffer), bitmap._FT_Bitmap.buffer,
             pitch * face.glyph.bitmap.rows)
 
     I = ImageSurface(FORMAT_ARGB32, width, rows)
-    ndR = ndarray(shape=(rows,width), buffer=whole_thing,
+    ndR = ndarray(shape=(rows,width), buffer=copybuffer,
                   dtype=ubyte, order='C',
                   offset=0,
                   strides=[pitch*3, 1])
-    ndG = ndarray(shape=(rows,width), buffer=whole_thing,
+    ndG = ndarray(shape=(rows,width), buffer=copybuffer,
                   dtype=ubyte, order='C',
                   offset=pitch,
                   strides=[pitch*3, 1])
-    ndB = ndarray(shape=(rows,width), buffer=whole_thing,
+    ndB = ndarray(shape=(rows,width), buffer=copybuffer,
                   dtype=ubyte, order='C',
                   offset=2*pitch,
                   strides=[pitch*3, 1])

--- a/examples/glyph-lcd-cairo.py
+++ b/examples/glyph-lcd-cairo.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+#
+#  pycairo/cairocffi-based glyph-lcd example - Copyright 2017 Hin-Tak Leung
+#  Distributed under the terms of the new BSD license.
+#
+#  rewrite of the numply,matplotlib-based example from Nicolas P. Rougier
+#  - Not immitating the upside-downness
+#  - Do LCD_V side by side also
+#
+#  Limitation: Suface.get_data() is not in the "python 3, pycairo < 1.11" combo.
+#
+# -----------------------------------------------------------------------------
+'''
+Glyph bitmap LCD display (sub-pixel) rendering
+'''
+from freetype import *
+# use Matrix() from Cairo instead of from Freetype
+from cairo import Context, ImageSurface, FORMAT_ARGB32, SurfacePattern, FILTER_BEST, Matrix
+
+if __name__ == '__main__':
+    from PIL import Image
+    from numpy import ndarray, ubyte, uint32
+
+    face = Face('./Vera.ttf')
+    face.set_char_size( 48*64 )
+    face.load_char('S', FT_LOAD_RENDER |
+                        FT_LOAD_TARGET_LCD )
+    bitmap = face.glyph.bitmap
+    width  = face.glyph.bitmap.width//3
+    rows   = face.glyph.bitmap.rows
+    pitch  = face.glyph.bitmap.pitch
+    whole_thing = (c_ubyte * (pitch * rows))()
+    memmove(pointer(whole_thing), bitmap._FT_Bitmap.buffer,
+            pitch * rows)
+
+    I = ImageSurface(FORMAT_ARGB32, width, rows)
+    ndR = ndarray(shape=(rows,width), buffer=whole_thing,
+                  dtype=ubyte, order='C',
+                  offset=0,
+                  strides=[pitch, 3])
+    ndG = ndarray(shape=(rows,width), buffer=whole_thing,
+                  dtype=ubyte, order='C',
+                  offset=1,
+                  strides=[pitch, 3])
+    ndB = ndarray(shape=(rows,width), buffer=whole_thing,
+                  dtype=ubyte, order='C',
+                  offset=2,
+                  strides=[pitch, 3])
+    ndI = ndarray(shape=(rows,width), buffer=I.get_data(),
+                  dtype=uint32, order='C',
+                  strides=[I.get_stride(), 4])
+    ndI[:,:] = 4278190080 + ndR[:,:] * 65536 + ndG[:,:] * 256 + ndB[:,:]
+    I.mark_dirty()
+
+    surface = ImageSurface(FORMAT_ARGB32, 800, 600)
+    ctx = Context(surface)
+
+    ctx.set_source_surface(I, 0, 0)
+    pattern = ctx.get_source()
+    SurfacePattern.set_filter(pattern, FILTER_BEST)
+    scale = 480.0 / rows
+    scalematrix = Matrix()
+    scalematrix.scale(1.0/scale,1.0/scale)
+    scalematrix.translate(-(400.0 - width *scale /2.0 )+200, -60)
+    pattern.set_matrix(scalematrix)
+    ctx.paint()
+
+    # we need this later for shifting the taller LCD_V glyph up.
+    rows_old = rows
+
+    # LCD_V
+    face.load_char('S', FT_LOAD_RENDER |
+                        FT_LOAD_TARGET_LCD_V )
+    bitmap = face.glyph.bitmap
+    width  = face.glyph.bitmap.width
+    rows   = face.glyph.bitmap.rows//3
+    pitch  = face.glyph.bitmap.pitch
+    whole_thing = (c_ubyte * (pitch * face.glyph.bitmap.rows))()
+    memmove(pointer(whole_thing), bitmap._FT_Bitmap.buffer,
+            pitch * face.glyph.bitmap.rows)
+
+    I = ImageSurface(FORMAT_ARGB32, width, rows)
+    ndR = ndarray(shape=(rows,width), buffer=whole_thing,
+                  dtype=ubyte, order='C',
+                  offset=0,
+                  strides=[pitch*3, 1])
+    ndG = ndarray(shape=(rows,width), buffer=whole_thing,
+                  dtype=ubyte, order='C',
+                  offset=pitch,
+                  strides=[pitch*3, 1])
+    ndB = ndarray(shape=(rows,width), buffer=whole_thing,
+                  dtype=ubyte, order='C',
+                  offset=2*pitch,
+                  strides=[pitch*3, 1])
+    ndI = ndarray(shape=(rows,width), buffer=I.get_data(),
+                  dtype=uint32, order='C',
+                  strides=[I.get_stride(), 4])
+    ndI[:,:] = 4278190080 + ndR[:,:] * 65536 + ndG[:,:] * 256 + ndB[:,:]
+    I.mark_dirty()
+
+    ctx.set_source_surface(I, 0, 0)
+    pattern = ctx.get_source()
+    SurfacePattern.set_filter(pattern, FILTER_BEST)
+    # Re-use the sane scale (LVD_V taller than LCD),
+    # but adjust vertical position to line up mid-height of glyphs
+    adjust = (rows - rows_old) * 240.0 /rows
+    scalematrix.translate(-400, adjust)
+    pattern.set_matrix(scalematrix)
+    ctx.paint()
+    #
+    surface.flush()
+    surface.write_to_png("glyph-lcd-cairo.png")
+    Image.open("glyph-lcd-cairo.png").show()

--- a/examples/glyph-lcd-cairo.py
+++ b/examples/glyph-lcd-cairo.py
@@ -48,9 +48,12 @@ if __name__ == '__main__':
                   dtype=ubyte, order='C',
                   offset=2,
                   strides=[pitch, 3])
-    ndI = ndarray(shape=(rows,width), buffer=I.get_data(),
-                  dtype=uint32, order='C',
-                  strides=[I.get_stride(), 4])
+    try:
+        ndI = ndarray(shape=(rows,width), buffer=I.get_data(),
+                      dtype=uint32, order='C',
+                      strides=[I.get_stride(), 4])
+    except NotImplementedError:
+       raise SystemExit("For python 3.x, you need pycairo >= 1.11+ (from https://github.com/pygobject/pycairo)")
     # 255 * 2**24 = opaque
     ndI[:,:] = 255 * 2**24 + ndR[:,:] * 2**16 + ndG[:,:] * 2**8 + ndB[:,:]
     I.mark_dirty()

--- a/examples/glyph-lcd.py
+++ b/examples/glyph-lcd.py
@@ -7,7 +7,7 @@
 #
 # -----------------------------------------------------------------------------
 '''
-Glyph bitmap monochrome rendring
+Glyph bitmap LCD display (sub-pixel) rendering
 '''
 from freetype import *
 

--- a/examples/glyph-mono+alpha-cairo.py
+++ b/examples/glyph-mono+alpha-cairo.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+#
+#  pycairo/cairocffi-based glyph-mono/alpha example - Copyright 2017 Hin-Tak Leung
+#  Distributed under the terms of the new BSD license.
+#
+#  rewrite of the numply,matplotlib-based example from Nicolas P. Rougier
+#  - Not immitating the upside-downness of glyph-monochrome/glyph-alpha
+
+#  This script default to normal(8-bit) rendering, but render to mono
+#  if any argument is specified.
+#
+#  Mono rendering requires libtiff on small-endian platforms. See
+#  comments in bitmap_to_surface.py.
+#
+# -----------------------------------------------------------------------------
+
+'''
+Glyph bitmap monochrome/alpha rendring
+'''
+from freetype import *
+
+# use Matrix() from Cairo instead of from Freetype
+from cairo import Context, ImageSurface, FORMAT_ARGB32, SurfacePattern, FILTER_BEST, Matrix
+from bitmap_to_surface import make_image_surface
+
+if __name__ == '__main__':
+    from PIL import Image
+    import sys
+
+    face = Face('./Vera.ttf')
+    face.set_char_size( 48*64 )
+
+    if len(sys.argv) < 2:
+        # Normal(8-bit) Rendering
+        face.load_char('S', FT_LOAD_RENDER |
+                       FT_LOAD_TARGET_NORMAL )
+    else:
+        # Mono(1-bit) Rendering
+        face.load_char('S', FT_LOAD_RENDER |
+                       FT_LOAD_TARGET_MONO )
+
+    bitmap = face.glyph.bitmap
+    width  = face.glyph.bitmap.width
+    rows   = face.glyph.bitmap.rows
+    pitch  = face.glyph.bitmap.pitch
+
+    glyph_surface = make_image_surface(face.glyph.bitmap)
+
+    surface = ImageSurface(FORMAT_ARGB32, 800, 600)
+    ctx = Context(surface)
+    ctx.rectangle(0,0,800,600)
+    ctx.set_line_width(0)
+    ctx.set_source_rgb (0.5 , 0.5, 0.5)
+    ctx.fill()
+    #
+    scale = 480.0 / rows
+    ctx.set_source_surface(glyph_surface, 0, 0)
+    pattern = ctx.get_source()
+    SurfacePattern.set_filter(pattern, FILTER_BEST)
+    scalematrix = Matrix()
+    scalematrix.scale(1.0/scale,1.0/scale)
+    scalematrix.translate(-(400.0 - width *scale /2.0 ), -60)
+    pattern.set_matrix(scalematrix)
+    ctx.set_source_rgb (0 , 0, 1)
+    ctx.mask(pattern)
+    ctx.fill()
+    surface.flush()
+    surface.write_to_png("glyph-mono+alpha-cairo.png")
+    Image.open("glyph-mono+alpha-cairo.png").show()

--- a/examples/glyph-outline-cairo.py
+++ b/examples/glyph-outline-cairo.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+#
+#  pycairo/cairocffi-based glyph-outline example - Copyright 2017 Hin-Tak Leung
+#  Distributed under the terms of the new BSD license.
+#
+#  rewrite of the numply,matplotlib-based example from Nicolas P. Rougier
+#
+# -----------------------------------------------------------------------------
+'''
+Glyph outline rendering
+'''
+from freetype import *
+
+# using Matrix class from Cairo, instead of FreeType's
+from cairo import Context, ImageSurface, FORMAT_ARGB32, SurfacePattern, FILTER_BEST, Matrix
+from bitmap_to_surface import make_image_surface
+
+if __name__ == '__main__':
+    from PIL import Image
+
+    face = Face('./Vera.ttf')
+    face.set_char_size( 4*48*64 )
+    flags = FT_LOAD_DEFAULT | FT_LOAD_NO_BITMAP
+    face.load_char('S', flags )
+    slot = face.glyph
+    glyph = slot.get_glyph()
+    stroker = Stroker( )
+    stroker.set(64, FT_STROKER_LINECAP_ROUND, FT_STROKER_LINEJOIN_ROUND, 0 )
+    glyph.stroke( stroker , True )
+    blyph = glyph.to_bitmap(FT_RENDER_MODE_NORMAL, Vector(0,0), True )
+    bitmap = blyph.bitmap
+    width, rows, pitch = bitmap.width, bitmap.rows, bitmap.pitch
+    surface = ImageSurface(FORMAT_ARGB32, 600, 800)
+    ctx = Context(surface)
+    Z = make_image_surface(bitmap)
+    ctx.set_source_surface(Z, 0, 0)
+    scale = 640.0 / rows
+    patternZ = ctx.get_source()
+    SurfacePattern.set_filter(patternZ, FILTER_BEST)
+    scalematrix = Matrix()
+    scalematrix.scale(1.0/scale,1.0/scale)
+    scalematrix.translate(-(300.0 - width *scale /2.0 ), -80)
+    patternZ.set_matrix(scalematrix)
+    ctx.set_source_rgb (0 , 0, 1)
+    ctx.mask(patternZ)
+    ctx.fill()
+    surface.flush()
+    surface.write_to_png("glyph-outline-cairo.png")
+    Image.open("glyph-outline-cairo.png").show()

--- a/examples/glyph-vector-2-cairo.py
+++ b/examples/glyph-vector-2-cairo.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+#
+#  pycairo/cairocffi-based glyph-vector-2 example - Copyright 2017 Hin-Tak Leung
+#  Distributed under the terms of the new BSD license.
+#
+#  rewrite of the numply,matplotlib-based example from Nicolas P. Rougier
+#  - The code is strickly speaking not optimal, as it ignores the 3rd order
+#    bezier curve bit and always intepolate between off-curve points.
+#    This is only correct for truetype fonts (which only use 2nd order bezier curves).
+#  - Also it seems to assume the first point is always on curve; this is
+#    unusual but legal.
+#
+# -----------------------------------------------------------------------------
+'''
+Show how to access glyph outline description.
+'''
+from freetype import *
+# using Matrix class from Cairo, instead of FreeType's
+from cairo import Context, SVGSurface, Matrix, SurfacePattern, FILTER_BEST
+
+from bitmap_to_surface import make_image_surface
+
+if __name__ == '__main__':
+    import numpy
+    from PIL import Image
+
+    # Replacement for Path enums:
+    STOP, MOVETO, LINETO, CURVE3, CURVE4 = 0, 1, 2, 3, 4
+    def tag_meaning(tag):
+        # return on/off_curve(), is_3rd_order_control_point()
+        return [tag & 1 == 1, tag & 2 == 2]
+
+    face = Face('./Vera.ttf')
+    face.set_char_size( 32*64 )
+    face.load_char('g')
+    slot = face.glyph
+
+    bitmap = face.glyph.bitmap
+    width  = face.glyph.bitmap.width
+    rows   = face.glyph.bitmap.rows
+    pitch  = face.glyph.bitmap.pitch
+
+    Z = make_image_surface(bitmap)
+
+    outline = slot.outline
+    points = numpy.array(outline.points, dtype=[('x',float), ('y',float)])
+    x, y = points['x'], points['y']
+
+    bbox = outline.get_bbox()
+
+    MARGIN  = 10
+    scale = 3
+
+    width_s = ((bbox.xMax - bbox.xMin)//scale + 2 * MARGIN)
+    height_s = ((bbox.yMax - bbox.yMin)//scale + 2 * MARGIN)
+
+    surface = SVGSurface('glyph-vector-2-cairo.svg',
+                         width_s,
+                         height_s)
+    ctx = Context(surface)
+    ctx.set_source_rgb(1,1,1)
+    ctx.paint()
+    ctx.save()
+    ctx.scale(1.0/scale,1.0/scale)
+    ctx.translate(-bbox.xMin + MARGIN * scale,-bbox.yMin + MARGIN * scale)
+    ctx.transform(Matrix(1,0,0,-1))
+    ctx.translate(0, -(bbox.yMax + bbox.yMin)) # difference!
+
+    start, end = 0, 0
+
+    VERTS, CODES = [], []
+    # Iterate over each contour
+    for i in range(len(outline.contours)):
+        end    = outline.contours[i]
+        points = outline.points[start:end+1]
+        points.append(points[0])
+        tags   = outline.tags[start:end+1]
+        tags.append(tags[0])
+
+        segments = [ [points[0],], ]
+        for j in range(1, len(points) ):
+            segments[-1].append(points[j])
+            if tags[j] & (1 << 0) and j < (len(points)-1):
+                segments.append( [points[j],] )
+        verts = [points[0], ]
+        codes = [MOVETO,]
+        for segment in segments:
+            if len(segment) == 2:
+                verts.extend(segment[1:])
+                codes.extend([LINETO])
+            elif len(segment) == 3:
+                verts.extend(segment[1:])
+                codes.extend([CURVE3, CURVE3])
+            else:
+                verts.append(segment[1])
+                codes.append(CURVE3)
+                for i in range(1,len(segment)-2):
+                    A,B = segment[i], segment[i+1]
+                    C = ((A[0]+B[0])/2.0, (A[1]+B[1])/2.0)
+                    verts.extend([ C, B ])
+                    codes.extend([ CURVE3, CURVE3])
+                verts.append(segment[-1])
+                codes.append(CURVE3)
+        VERTS.extend(verts)
+        CODES.extend(codes)
+        start = end+1
+
+
+    # Draw glyph
+    ctx.new_path()
+    ctx.set_source_rgba(0.8,0.5,0.8, 1)
+    i = 0
+    while (i < len(CODES)):
+        if (CODES[i] == MOVETO):
+            ctx.move_to(VERTS[i][0],VERTS[i][1])
+            i += 1
+        elif (CODES[i] == LINETO):
+            ctx.line_to(VERTS[i][0],VERTS[i][1])
+            i += 1
+        elif (CODES[i] == CURVE3):
+            ctx.curve_to(VERTS[i][0],VERTS[i][1],
+                         VERTS[i+1][0],VERTS[i+1][1], # undocumented
+                         VERTS[i+1][0],VERTS[i+1][1])
+            i += 2
+        else:
+            raise NotImplementedError("Cannot cope!")
+    ctx.fill_preserve()
+    ctx.set_source_rgb(0,0,0)
+    ctx.set_line_width(6)
+    ctx.stroke()
+    ctx.restore()
+
+    scale2 = (height_s - 2.0 * MARGIN)/rows
+
+    ctx.set_source_surface(Z, 0, 0)
+    pattern = ctx.get_source()
+    SurfacePattern.set_filter(pattern, FILTER_BEST)
+    scalematrix = Matrix()
+    scalematrix.scale(1.0/scale2, 1.0/scale2)
+    scalematrix.translate(-( width_s/2.0  - width *scale2 /2.0 ), -MARGIN)
+    pattern.set_matrix(scalematrix)
+    ctx.set_source_rgba (0, 0, 0, 0.7)
+    ctx.mask(pattern)
+    ctx.fill()
+
+
+    surface.flush()
+    surface.write_to_png("glyph-vector-2-cairo.png")
+    surface.finish()
+    Image.open("glyph-vector-2-cairo.png").show()

--- a/examples/glyph-vector-2-cairo.py
+++ b/examples/glyph-vector-2-cairo.py
@@ -52,8 +52,14 @@ if __name__ == '__main__':
     MARGIN  = 10
     scale = 3
 
-    width_s = ((bbox.xMax - bbox.xMin)//scale + 2 * MARGIN)
-    height_s = ((bbox.yMax - bbox.yMin)//scale + 2 * MARGIN)
+    def Floor64(x):
+        return (x//64) * 64
+
+    def Ceil64(x):
+        return ((x+63)//64) * 64
+
+    width_s = (width * 64)//scale + 2 * MARGIN
+    height_s = (rows * 64)//scale + 2 * MARGIN
 
     surface = SVGSurface('glyph-vector-2-cairo.svg',
                          width_s,
@@ -63,9 +69,9 @@ if __name__ == '__main__':
     ctx.paint()
     ctx.save()
     ctx.scale(1.0/scale,1.0/scale)
-    ctx.translate(-bbox.xMin + MARGIN * scale,-bbox.yMin + MARGIN * scale)
+    ctx.translate(-Floor64(bbox.xMin) + MARGIN * scale,-Floor64(bbox.yMin) + MARGIN * scale)
     ctx.transform(Matrix(1,0,0,-1))
-    ctx.translate(0, -(bbox.yMax + bbox.yMin)) # difference!
+    ctx.translate(0, -(Ceil64(bbox.yMax) + Floor64(bbox.yMin))) # difference!
 
     start, end = 0, 0
 

--- a/examples/glyph-vector-2-cairo.py
+++ b/examples/glyph-vector-2-cairo.py
@@ -6,7 +6,7 @@
 #  Distributed under the terms of the new BSD license.
 #
 #  rewrite of the numply,matplotlib-based example from Nicolas P. Rougier
-#  - The code is strickly speaking not optimal, as it ignores the 3rd order
+#  - The code is incomplete and over-simplified, as it ignores the 3rd order
 #    bezier curve bit and always intepolate between off-curve points.
 #    This is only correct for truetype fonts (which only use 2nd order bezier curves).
 #  - Also it seems to assume the first point is always on curve; this is

--- a/examples/glyph-vector-2.py
+++ b/examples/glyph-vector-2.py
@@ -5,6 +5,12 @@
 #  FreeType high-level python API - Copyright 2011-2015 Nicolas P. Rougier
 #  Distributed under the terms of the new BSD license.
 #
+#  - The code is strickly speaking not optimal, as it ignores the 3rd order
+#    bezier curve bit and always intepolate between off-curve points.
+#    This is only correct for truetype fonts (which only use 2nd order bezier curves).
+#  - Also it seems to assume the first point is always on curve; this is
+#    unusual but legal.
+#
 # -----------------------------------------------------------------------------
 '''
 Show how to access glyph outline description.

--- a/examples/glyph-vector-2.py
+++ b/examples/glyph-vector-2.py
@@ -94,5 +94,5 @@ if __name__ == '__main__':
     axis.set_xlim(x.min(), x.max())
     axis.set_ylim(y.min(), y.max())
 
-    plt.savefig('test.svg')
+    plt.savefig('glyph-vector-2.svg')
     plt.show()

--- a/examples/glyph-vector-2.py
+++ b/examples/glyph-vector-2.py
@@ -5,7 +5,7 @@
 #  FreeType high-level python API - Copyright 2011-2015 Nicolas P. Rougier
 #  Distributed under the terms of the new BSD license.
 #
-#  - The code is strickly speaking not optimal, as it ignores the 3rd order
+#  - The code is incomplete and over-simplified, as it ignores the 3rd order
 #    bezier curve bit and always intepolate between off-curve points.
 #    This is only correct for truetype fonts (which only use 2nd order bezier curves).
 #  - Also it seems to assume the first point is always on curve; this is

--- a/examples/glyph-vector-cairo.py
+++ b/examples/glyph-vector-cairo.py
@@ -7,10 +7,12 @@
 #
 #  rewrite of the numply,matplotlib-based example from Nicolas P. Rougier
 #  - The code is incomplete and over-simplified, as it ignores the 3rd order
-#    bezier curve bit and always intepolate between off-curve points.
+#    bezier curve bit when intepolating between off-curve points.
 #    This is only correct for truetype fonts (which only use 2nd order bezier curves).
 #  - Also it seems to assume the first point is always on curve; this is
 #    unusual but legal.
+#
+#  Can cope with well-behaved Postscript/CFF fonts too.
 #
 # -----------------------------------------------------------------------------
 '''
@@ -31,10 +33,6 @@ if __name__ == '__main__':
     # Replacement for Path enums:
     STOP, MOVETO, LINETO, CURVE3, CURVE4 = 0, 1, 2, 3, 4
 
-    def tag_meaning(tag):
-        # return on/off_curve(), is_3rd_order_control_point()
-        return [tag & 1 == 1, tag & 2 == 2]
-
     face = Face('./Vera.ttf')
     face.set_char_size( 48*64 )
     face.load_char('S')
@@ -54,7 +52,7 @@ if __name__ == '__main__':
     ctx.transform(Matrix(1,0,0,-1))
     ctx.translate(0, -(cbox.yMax + cbox.yMin)) # difference!
 
-    meaning = [tag_meaning(tag) for tag in outline.tags]
+    Curve_Tag = [FT_Curve_Tag(tag) for tag in outline.tags]
 
     start, end = 0, 0
 
@@ -82,7 +80,7 @@ if __name__ == '__main__':
         ctx.new_path()
         ctx.set_source_rgb(0,0,1)
         for j in range(start, end+1):
-            if ( meaning[j][0] ):
+            if ( Curve_Tag[j] == FT_Curve_Tag_On ):
                 point = outline.points[j]
                 ctx.move_to(point[0],point[1])
                 ctx.arc(point[0], point[1], 40, 0, 2 * math.pi)
@@ -91,7 +89,7 @@ if __name__ == '__main__':
         ctx.new_path()
         ctx.set_source_rgb(1,0,0)
         for j in range(start, end+1):
-            if ( not meaning[j][0] ):
+            if ( Curve_Tag[j] != FT_Curve_Tag_On ):
                 point = outline.points[j]
                 ctx.move_to(point[0],point[1])
                 ctx.arc(point[0], point[1], 10, 0, 2 * math.pi)
@@ -105,10 +103,11 @@ if __name__ == '__main__':
         segments = [ [points[0],], ]
         for j in range(1, len(points) ):
             segments[-1].append(points[j])
-            if tags[j] & (1 << 0) and j < (len(points)-1):
+            if ( FT_Curve_Tag( tags[j] ) == FT_Curve_Tag_On ) and j < (len(points)-1):
                 segments.append( [points[j],] )
         verts = [points[0], ]
         codes = [MOVETO,]
+        tags.pop()
         for segment in segments:
             if len(segment) == 2:
                 verts.extend(segment[1:])
@@ -116,7 +115,13 @@ if __name__ == '__main__':
             elif len(segment) == 3:
                 verts.extend(segment[1:])
                 codes.extend([CURVE3, CURVE3])
+            elif ( len(segment) == 4 ) \
+                 and ( FT_Curve_Tag(tags[1]) == FT_Curve_Tag_Cubic ) \
+                 and ( FT_Curve_Tag(tags[2]) == FT_Curve_Tag_Cubic ):
+                verts.extend(segment[1:])
+                codes.extend([CURVE4, CURVE4, CURVE4])
             else:
+                # Intepolation code
                 verts.append(segment[1])
                 codes.append(CURVE3)
                 for i in range(1,len(segment)-2):
@@ -126,6 +131,7 @@ if __name__ == '__main__':
                     codes.extend([ CURVE3, CURVE3])
                 verts.append(segment[-1])
                 codes.append(CURVE3)
+            [tags.pop() for x in range(len(segment) - 1)]
         VERTS.extend(verts)
         CODES.extend(codes)
         start = end+1
@@ -145,8 +151,11 @@ if __name__ == '__main__':
                          VERTS[i+1][0],VERTS[i+1][1], # undocumented
                          VERTS[i+1][0],VERTS[i+1][1])
             i += 2
-        else:
-            raise NotImplementedError("Cannot cope!")
+        elif (CODES[i] == CURVE4):
+            ctx.curve_to(VERTS[i][0],VERTS[i][1],
+                         VERTS[i+1][0],VERTS[i+1][1],
+                         VERTS[i+2][0],VERTS[i+2][1])
+            i += 3
     ctx.fill()
 
     surface.flush()

--- a/examples/glyph-vector-cairo.py
+++ b/examples/glyph-vector-cairo.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+#
+#  pycairo/cairocffi-based glyph-vector example - Copyright 2017 Hin-Tak Leung
+#  Distributed under the terms of the new BSD license.
+#
+#  rewrite of the numply,matplotlib-based example from Nicolas P. Rougier
+#  - The code is strickly speaking not optimal, as it ignores the 3rd order
+#    bezier curve bit and always intepolate between off-curve points.
+#    This is only correct for truetype fonts (which only use 2nd order bezier curves).
+#  - Also it seems to assume the first point is always on curve; this is
+#    unusual but legal.
+#
+# -----------------------------------------------------------------------------
+'''
+Show how to access glyph outline description.
+'''
+from freetype import *
+
+# using Matrix class from Cairo, instead of FreeType's
+from cairo import Context, ImageSurface, FORMAT_ARGB32, Matrix
+
+# use math.pi for drawing circles
+import math
+
+if __name__ == '__main__':
+    import numpy
+    from PIL import Image
+
+    # Replacement for Path enums:
+    STOP, MOVETO, LINETO, CURVE3, CURVE4 = 0, 1, 2, 3, 4
+
+    def tag_meaning(tag):
+        # return on/off_curve(), is_3rd_order_control_point()
+        return [tag & 1 == 1, tag & 2 == 2]
+
+    face = Face('./Vera.ttf')
+    face.set_char_size( 48*64 )
+    face.load_char('S')
+    slot = face.glyph
+
+    outline = slot.outline
+    points = numpy.array(outline.points, dtype=[('x',float), ('y',float)])
+    x, y = points['x'], points['y']
+
+    cbox = outline.get_cbox()
+    surface = ImageSurface(FORMAT_ARGB32,
+                           (cbox.xMax - cbox.xMin)//4 + 20,
+                           (cbox.yMax - cbox.yMin)//4 + 20)
+    ctx = Context(surface)
+    ctx.scale(0.25,0.25)
+    ctx.translate(-cbox.xMin + 40,-cbox.yMin + 40)
+    ctx.transform(Matrix(1,0,0,-1))
+    ctx.translate(0, -(cbox.yMax + cbox.yMin)) # difference!
+
+    meaning = [tag_meaning(tag) for tag in outline.tags]
+
+    start, end = 0, 0
+
+    VERTS, CODES = [], []
+    # Iterate over each contour
+    ctx.set_source_rgb(0.5,0.5,0.5)
+    for i in range(len(outline.contours)):
+        end    = outline.contours[i]
+
+        ctx.move_to(outline.points[start][0],outline.points[start][1])
+        for j in range(start, end+1):
+            point = outline.points[j]
+            ctx.line_to(point[0],point[1])
+        #back to origin
+        ctx.line_to(outline.points[start][0], outline.points[start][1])
+        start = end+1
+    ctx.fill_preserve()
+    ctx.set_source_rgb(0,1,0)
+    ctx.stroke()
+
+    start, end = 0, 0
+    for i in range(len(outline.contours)):
+        end    = outline.contours[i]
+
+        ctx.new_path()
+        ctx.set_source_rgb(0,0,1)
+        for j in range(start, end+1):
+            if ( meaning[j][0] ):
+                point = outline.points[j]
+                ctx.move_to(point[0],point[1])
+                ctx.arc(point[0], point[1], 40, 0, 2 * math.pi)
+        ctx.fill()
+
+        ctx.new_path()
+        ctx.set_source_rgb(1,0,0)
+        for j in range(start, end+1):
+            if ( not meaning[j][0] ):
+                point = outline.points[j]
+                ctx.move_to(point[0],point[1])
+                ctx.arc(point[0], point[1], 10, 0, 2 * math.pi)
+        ctx.fill()
+
+        points = outline.points[start:end+1]
+        points.append(points[0])
+        tags   = outline.tags[start:end+1]
+        tags.append(tags[0])
+
+        segments = [ [points[0],], ]
+        for j in range(1, len(points) ):
+            segments[-1].append(points[j])
+            if tags[j] & (1 << 0) and j < (len(points)-1):
+                segments.append( [points[j],] )
+        verts = [points[0], ]
+        codes = [MOVETO,]
+        for segment in segments:
+            if len(segment) == 2:
+                verts.extend(segment[1:])
+                codes.extend([LINETO])
+            elif len(segment) == 3:
+                verts.extend(segment[1:])
+                codes.extend([CURVE3, CURVE3])
+            else:
+                verts.append(segment[1])
+                codes.append(CURVE3)
+                for i in range(1,len(segment)-2):
+                    A,B = segment[i], segment[i+1]
+                    C = ((A[0]+B[0])/2.0, (A[1]+B[1])/2.0)
+                    verts.extend([ C, B ])
+                    codes.extend([ CURVE3, CURVE3])
+                verts.append(segment[-1])
+                codes.append(CURVE3)
+        VERTS.extend(verts)
+        CODES.extend(codes)
+        start = end+1
+
+    ctx.new_path()
+    ctx.set_source_rgba(1,1,0, 0.5)
+    i = 0
+    while (i < len(CODES)):
+        if (CODES[i] == MOVETO):
+            ctx.move_to(VERTS[i][0],VERTS[i][1])
+            i += 1
+        elif (CODES[i] == LINETO):
+            ctx.line_to(VERTS[i][0],VERTS[i][1])
+            i += 1
+        elif (CODES[i] == CURVE3):
+            ctx.curve_to(VERTS[i][0],VERTS[i][1],
+                         VERTS[i+1][0],VERTS[i+1][1], # undocumented
+                         VERTS[i+1][0],VERTS[i+1][1])
+            i += 2
+        else:
+            raise NotImplementedError("Cannot cope!")
+    ctx.fill()
+
+    surface.flush()
+    surface.write_to_png("glyph-vector-cairo.png")
+    Image.open("glyph-vector-cairo.png").show()

--- a/examples/glyph-vector-cairo.py
+++ b/examples/glyph-vector-cairo.py
@@ -6,7 +6,7 @@
 #  Distributed under the terms of the new BSD license.
 #
 #  rewrite of the numply,matplotlib-based example from Nicolas P. Rougier
-#  - The code is strickly speaking not optimal, as it ignores the 3rd order
+#  - The code is incomplete and over-simplified, as it ignores the 3rd order
 #    bezier curve bit and always intepolate between off-curve points.
 #    This is only correct for truetype fonts (which only use 2nd order bezier curves).
 #  - Also it seems to assume the first point is always on curve; this is

--- a/examples/glyph-vector.py
+++ b/examples/glyph-vector.py
@@ -5,6 +5,12 @@
 #  FreeType high-level python API - Copyright 2011 Nicolas P. Rougier
 #  Distributed under the terms of the new BSD license.
 #
+#  - The code is strickly speaking not optimal, as it ignores the 3rd order
+#    bezier curve bit and always intepolate between off-curve points.
+#    This is only correct for truetype fonts (which only use 2nd order bezier curves).
+#  - Also it seems to assume the first point is always on curve; this is
+#    unusual but legal.
+#
 # -----------------------------------------------------------------------------
 '''
 Show how to access glyph outline description.

--- a/examples/glyph-vector.py
+++ b/examples/glyph-vector.py
@@ -5,7 +5,7 @@
 #  FreeType high-level python API - Copyright 2011 Nicolas P. Rougier
 #  Distributed under the terms of the new BSD license.
 #
-#  - The code is strickly speaking not optimal, as it ignores the 3rd order
+#  - The code is incomplete and over-simplified, as it ignores the 3rd order
 #    bezier curve bit and always intepolate between off-curve points.
 #    This is only correct for truetype fonts (which only use 2nd order bezier curves).
 #  - Also it seems to assume the first point is always on curve; this is

--- a/examples/hello-world-cairo.py
+++ b/examples/hello-world-cairo.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+#
+#  pycairo/cairocffi-based "Hello World" example - Copyright 2017 Hin-Tak Leung
+#  Distributed under the terms of the new BSD license.
+#
+#  rewrite of the numply,matplotlib-based example from Nicolas P. Rougier
+#
+# -----------------------------------------------------------------------------
+from freetype import *
+
+from cairo import Context, ImageSurface, FORMAT_A8
+from bitmap_to_surface import make_image_surface
+
+if __name__ == '__main__':
+    from PIL import Image
+
+    face = Face('./Vera.ttf')
+    text = 'Hello World !'
+    face.set_char_size( 48*64 )
+    slot = face.glyph
+
+    # First pass to compute bbox
+    width, height, baseline = 0, 0, 0
+    previous = 0
+    for i,c in enumerate(text):
+        face.load_char(c)
+        bitmap = slot.bitmap
+        height = max(height,
+                     bitmap.rows + max(0,-(slot.bitmap_top-bitmap.rows)))
+        baseline = max(baseline, max(0,-(slot.bitmap_top-bitmap.rows)))
+        kerning = face.get_kerning(previous, c)
+        width += (slot.advance.x >> 6) + (kerning.x >> 6)
+        previous = c
+
+    Z = ImageSurface(FORMAT_A8, width, height)
+    ctx = Context(Z)
+
+    # Second pass for actual rendering
+    x, y = 0, 0
+    previous = 0
+    for c in text:
+        face.load_char(c)
+        bitmap = slot.bitmap
+        top = slot.bitmap_top
+        left = slot.bitmap_left
+        w,h = bitmap.width, bitmap.rows
+        y = height-baseline-top
+        kerning = face.get_kerning(previous, c)
+        x += (kerning.x >> 6)
+        # cairo does not like zero-width bitmap from the space character!
+        if (bitmap.width > 0):
+            glyph_surface = make_image_surface(face.glyph.bitmap)
+            ctx.set_source_surface(glyph_surface, x, y)
+            ctx.paint()
+        x += (slot.advance.x >> 6)
+        previous = c
+    Z.flush()
+    Z.write_to_png("hello-world-cairo.png")
+    Image.open("hello-world-cairo.png").show()

--- a/examples/wordle-cairo.py
+++ b/examples/wordle-cairo.py
@@ -140,7 +140,10 @@ if __name__ == '__main__':
     drawn_regions = Region()
     for size in sizes:
         angle = random.randint(-25,25)
-        L = make_label('Hello', './Vera.ttf', size, angle=angle)
+        try:
+            L = make_label('Hello', './Vera.ttf', size, angle=angle)
+        except NotImplementedError:
+            raise SystemExit("For python 3.x, you need pycairo >= 1.11+ (from https://github.com/pygobject/pycairo)")
         h = L.get_height()
         w = L.get_width()
         if h < H and w < W:

--- a/examples/wordle-cairo.py
+++ b/examples/wordle-cairo.py
@@ -10,6 +10,7 @@
 #
 #  This example behaves differently under pycairo 1.11+ (released in 2017-04-09).
 #  Auto-checked. On older pycairo, it does not draw partial patterns at the edges.
+#  Also, Suface.get_data() is not in the "python 3, pycairo < 1.11" combination.
 #
 # -----------------------------------------------------------------------------
 from math import cos, sin

--- a/examples/wordle-cairo.py
+++ b/examples/wordle-cairo.py
@@ -167,9 +167,8 @@ if __name__ == '__main__':
                     scalematrix.scale(1.0,1.0)
                     scalematrix.translate(w//2 - x, h//2 - y)
                     pattern.set_matrix(scalematrix)
-                    ctxI.mask(pattern)
                     ctxI.set_source_rgba(c,c,c,c)
-                    ctxI.fill()
+                    ctxI.mask(pattern)
                     drawn_regions.union(new_region)
                     break
     I.flush()

--- a/examples/wordle-cairo.py
+++ b/examples/wordle-cairo.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+#
+#  pycairo/cairocffi-based wordle example - Copyright 2017 Hin-Tak Leung
+#  Distributed under the terms of the new BSD license.
+#
+#  rewrite of the numply,matplotlib-based example from Nicolas P. Rougier
+#  - Cairo can paint partly off-screen, so this example does!
+#
+#  This example needs pycairo 1.11+ (released in 2017-04-09). Auto-checked.
+#
+# -----------------------------------------------------------------------------
+from math import cos, sin
+from numpy import random, sort, sqrt
+from freetype import *
+
+try:
+    from cairo import Region, RectangleInt, REGION_OVERLAP_OUT
+except ImportError:
+    raise RuntimeError('Region class not found; Need pycairo 1.11+')
+
+from cairo import Context, ImageSurface, FORMAT_A8, FORMAT_ARGB32, Matrix
+from bitmap_to_surface import make_image_surface
+
+def make_label(text, filename, size=12, angle=0):
+    '''
+    Parameters:
+    -----------
+    text : string
+        Text to be displayed
+    filename : string
+        Path to a font
+    size : int
+        Font size in 1/64th points
+    angle : float
+        Text angle in degrees
+    '''
+    face = Face(filename)
+    face.set_char_size( size*64 )
+    # FT_Angle is a 16.16 fixed-point value expressed in degrees.
+    angle = FT_Angle(angle * 65536)
+    matrix  = FT_Matrix( FT_Cos( angle ),
+                         - FT_Sin( angle ),
+                         FT_Sin( angle ) ,
+                         FT_Cos( angle ) )
+    flags = FT_LOAD_RENDER
+    pen = FT_Vector(0,0)
+    FT_Set_Transform( face._FT_Face, byref(matrix), byref(pen) )
+    previous = 0
+    xmin, xmax = 0, 0
+    ymin, ymax = 0, 0
+    for c in text:
+        face.load_char(c, flags)
+        kerning = face.get_kerning(previous, c)
+        previous = c
+        bitmap = face.glyph.bitmap
+        pitch  = face.glyph.bitmap.pitch
+        width  = face.glyph.bitmap.width
+        rows   = face.glyph.bitmap.rows
+        top    = face.glyph.bitmap_top
+        left   = face.glyph.bitmap_left
+        pen.x += kerning.x
+        x0 = (pen.x >> 6) + left
+        x1 = x0 + width
+        y0 = (pen.y >> 6) - (rows - top)
+        y1 = y0 + rows
+        xmin, xmax = min(xmin, x0),  max(xmax, x1)
+        ymin, ymax = min(ymin, y0), max(ymax, y1)
+        pen.x += face.glyph.advance.x
+        pen.y += face.glyph.advance.y
+
+    L = ImageSurface(FORMAT_A8, xmax-xmin, ymax-ymin)
+    previous = 0
+    pen.x, pen.y = 0, 0
+    ctx = Context(L)
+    for c in text:
+        face.load_char(c, flags)
+        kerning = face.get_kerning(previous, c)
+        previous = c
+        bitmap = face.glyph.bitmap
+        pitch  = face.glyph.bitmap.pitch
+        width  = face.glyph.bitmap.width
+        rows   = face.glyph.bitmap.rows
+        top    = face.glyph.bitmap_top
+        left   = face.glyph.bitmap_left
+        pen.x += kerning.x
+        x = (pen.x >> 6) - xmin + left
+        y = - (pen.y >> 6) + ymax - top
+        if (width > 0):
+            glyph_surface = make_image_surface(face.glyph.bitmap)
+            ctx.set_source_surface(glyph_surface, x, y)
+            ctx.paint()
+        pen.x += face.glyph.advance.x
+        pen.y += face.glyph.advance.y
+
+    L.flush()
+    return L
+
+
+if __name__ == '__main__':
+    from PIL import Image
+
+    n_words = 140
+    H, W, dpi = 600, 800, 72.0
+    I = ImageSurface(FORMAT_ARGB32, W, H)
+    ctxI = Context(I)
+    ctxI.rectangle(0,0,800,600)
+    ctxI.set_source_rgb (0.9, 0.9, 0.9)
+    ctxI.fill()
+    S = random.normal(0,1,n_words)
+    S = (S-S.min())/(S.max()-S.min())
+    S = sort(1-sqrt(S))[::-1]
+    sizes = (12 + S*48).astype(int).tolist()
+
+    def spiral():
+        eccentricity = 1.5
+        radius = 8
+        step = 0.1
+        t = 0
+        while True:
+            t += step
+            yield eccentricity*radius*t*cos(t), radius*t*sin(t)
+
+    drawn_regions = Region()
+    for size in sizes:
+        angle = random.randint(-25,25)
+        L = make_label('Hello', './Vera.ttf', size, angle=angle)
+        h = L.get_height()
+        w = L.get_width()
+        if h < H and w < W:
+            x0 = W//2 + (random.uniform()-.1)*50
+            y0 = H//2 + (random.uniform()-.1)*50
+            for dx,dy in spiral():
+                c = .25+.75*random.random()
+                x = int(x0+dx)
+                y = int(y0+dy)
+                new_region = RectangleInt(x-w//2, y-h//2, w, h)
+                if ( drawn_regions.contains_rectangle(new_region) == REGION_OVERLAP_OUT ):
+                    ctxI.set_source_surface(L, 0, 0)
+                    pattern = ctxI.get_source()
+                    scalematrix = Matrix()
+                    scalematrix.scale(1.0,1.0)
+                    scalematrix.translate(w//2 - x, h//2 - y)
+                    pattern.set_matrix(scalematrix)
+                    ctxI.mask(pattern)
+                    ctxI.set_source_rgb(c,0,c)
+                    ctxI.fill()
+                    drawn_regions.union(new_region)
+                    break
+    I.flush()
+    I.write_to_png("wordle-cairo.png")
+    Image.open("wordle-cairo.png").show()

--- a/examples/wordle-cairo.py
+++ b/examples/wordle-cairo.py
@@ -8,17 +8,31 @@
 #  rewrite of the numply,matplotlib-based example from Nicolas P. Rougier
 #  - Cairo can paint partly off-screen, so this example does!
 #
-#  This example needs pycairo 1.11+ (released in 2017-04-09). Auto-checked.
+#  This example behaves differently under pycairo 1.11+ (released in 2017-04-09).
+#  Auto-checked. On older pycairo, it does not draw partial patterns at the edges.
 #
 # -----------------------------------------------------------------------------
 from math import cos, sin
-from numpy import random, sort, sqrt
+from numpy import random, sort, sqrt, ndarray, ubyte
 from freetype import *
 
 try:
+    # pycairo 1.11+:
     from cairo import Region, RectangleInt, REGION_OVERLAP_OUT
 except ImportError:
-    raise RuntimeError('Region class not found; Need pycairo 1.11+')
+    # stubs for pycairo < 1.11:
+    class Region:
+        def __init__(self):
+            return
+        def union(self, rec):
+            return
+        def contains_rectangle(self, rec):
+            # inhibit drawing
+            return True
+    class RectangleInt:
+        def __init__(self, x, y, w, h):
+            return
+    REGION_OVERLAP_OUT = False
 
 from cairo import Context, ImageSurface, FORMAT_A8, FORMAT_ARGB32, Matrix
 from bitmap_to_surface import make_image_surface
@@ -101,12 +115,12 @@ def make_label(text, filename, size=12, angle=0):
 if __name__ == '__main__':
     from PIL import Image
 
-    n_words = 140
+    n_words = 200
     H, W, dpi = 600, 800, 72.0
-    I = ImageSurface(FORMAT_ARGB32, W, H)
+    I = ImageSurface(FORMAT_A8, W, H)
     ctxI = Context(I)
     ctxI.rectangle(0,0,800,600)
-    ctxI.set_source_rgb (0.9, 0.9, 0.9)
+    ctxI.set_source_rgba (0.9, 0.9, 0.9, 0)
     ctxI.fill()
     S = random.normal(0,1,n_words)
     S = (S-S.min())/(S.max()-S.min())
@@ -135,8 +149,18 @@ if __name__ == '__main__':
                 c = .25+.75*random.random()
                 x = int(x0+dx)
                 y = int(y0+dy)
+                checked = False
+                I.flush()
+                if not (x <= w//2 or y <= h//2 or x >= (W-w//2) or y >= (H-h//2)):
+                    ndI = ndarray(shape=(h,w), buffer=I.get_data(), dtype=ubyte, order='C',
+                                  offset=(x-w//2) + I.get_stride() * (y-h//2),
+                                  strides=[I.get_stride(), 1])
+                    ndL = ndarray(shape=(h,w), buffer=L.get_data(), dtype=ubyte, order='C',
+                                  strides=[L.get_stride(), 1])
+                    if ((ndI * ndL).sum() == 0):
+                       checked = True
                 new_region = RectangleInt(x-w//2, y-h//2, w, h)
-                if ( drawn_regions.contains_rectangle(new_region) == REGION_OVERLAP_OUT ):
+                if  (checked or ( drawn_regions.contains_rectangle(new_region) == REGION_OVERLAP_OUT )):
                     ctxI.set_source_surface(L, 0, 0)
                     pattern = ctxI.get_source()
                     scalematrix = Matrix()
@@ -144,7 +168,7 @@ if __name__ == '__main__':
                     scalematrix.translate(w//2 - x, h//2 - y)
                     pattern.set_matrix(scalematrix)
                     ctxI.mask(pattern)
-                    ctxI.set_source_rgb(c,0,c)
+                    ctxI.set_source_rgba(c,c,c,c)
                     ctxI.fill()
                     drawn_regions.union(new_region)
                     break

--- a/freetype/__init__.py
+++ b/freetype/__init__.py
@@ -650,8 +650,7 @@ class Outline( object ):
         which is dedicated to this single task.
         '''
         bbox = FT_BBox()
-        error = FT_Outline_Get_CBox(byref(self._FT_Outline), byref(bbox))
-        if error: raise FT_Exception(error)
+        FT_Outline_Get_CBox(byref(self._FT_Outline), byref(bbox))
         return BBox(bbox)
 
 

--- a/freetype/ft_enums/__init__.py
+++ b/freetype/ft_enums/__init__.py
@@ -9,6 +9,10 @@
 Freetype enum types
 -------------------
 
+FT_CURVE_TAGS: An enumeration type for each point on an outline to indicate
+               whether it describes a point used to control a line segment
+               or an arc.
+
 FT_PIXEL_MODES: An enumeration type used to describe the format of pixels in a
                 given bitmap. Note that additional formats may be added in the
                 future.
@@ -93,6 +97,7 @@ TT_NAME_IDS: Possible values of the `name' identifier field in the name
              records of the TTF `name' table.  These values are platform
              independent.
 '''
+from freetype.ft_enums.ft_curve_tags import *
 from freetype.ft_enums.ft_fstypes import *
 from freetype.ft_enums.ft_face_flags import *
 from freetype.ft_enums.ft_encodings import *

--- a/freetype/ft_enums/ft_curve_tags.py
+++ b/freetype/ft_enums/ft_curve_tags.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+#
+#  FreeType high-level python API - Copyright 2017 Hin-Tak Leung
+#  Distributed under the terms of the new BSD license.
+#
+# -----------------------------------------------------------------------------
+"""
+An enumeration type that lists the curve tags supported by FreeType 2.
+
+Each point of an outline has a specific tag which indicates whether it
+describes a point used to control a line segment or an arc. The tags can take
+the following values:
+
+FT_CURVE_TAG_ON
+
+  Used when the point is ‘on’ the curve. This corresponds to start and end
+  points of segments and arcs. The other tags specify what is called an ‘off’
+  point, i.e., a point which isn't located on the contour itself, but serves
+  as a control point for a Bézier arc.
+
+FT_CURVE_TAG_CONIC
+
+  Used for an ‘off’ point used to control a conic Bézier arc.
+
+FT_CURVE_TAG_CUBIC
+
+  Used for an ‘off’ point used to control a cubic Bézier arc.
+
+
+FT_Curve_Tag_On, FT_Curve_Tag_Conic, FT_Curve_Tag_Cubic are their
+correspondning mixed-case aliases.
+
+Use the FT_CURVE_TAG(tag) macro to filter out other, internally used flags.
+
+"""
+
+FT_CURVE_TAGS = {
+    'FT_CURVE_TAG_ON'    : 1,
+    'FT_CURVE_TAG_CONIC' : 0,
+    'FT_CURVE_TAG_CUBIC' : 2}
+globals().update(FT_CURVE_TAGS)
+
+FT_Curve_Tag_On     = FT_CURVE_TAG_ON
+FT_Curve_Tag_Conic  = FT_CURVE_TAG_CONIC
+FT_Curve_Tag_Cubic  = FT_CURVE_TAG_CUBIC
+
+def FT_CURVE_TAG( flag ):
+    return ( flag & 3 )
+
+# FreeType itself does not have mixed-case macros
+FT_Curve_Tag = FT_CURVE_TAG

--- a/freetype/ft_types.py
+++ b/freetype/ft_types.py
@@ -127,6 +127,9 @@ FT_Error   = c_int    # The FreeType error code type. A value of 0 is always
 FT_Fixed   = c_long   # This type is used to store 16.16 fixed float values,
                       # like scaling values or matrix coefficients.
 
+FT_Angle   = FT_Fixed # This type is used to model angle values in FreeType.  Note that the
+                      # angle is a 16.16 fixed-point value expressed in degrees.
+
 FT_Pointer = c_void_p # A simple typedef for a typeless pointer.
 
 FT_Pos     = c_long   # The type FT_Pos is used to store vectorial


### PR DESCRIPTION
    Should work also with cairocffi.
    
    TODO/Limitations:
    
    - glyph-mono+alpha requires libtiff on small-endian platforms
    for mono-rendering to bitswap correctly. It may be possible to use
    FT_Bitmap_Convert() instead. TODO
    
**edit** I wanted to do strikethrough to keep the paragraph but indicates that the below nolonger applies.
Already fixed by further commits later.
```
   - wordle requires pycairo 1.11+ (released only on 2017-04-09)
    for the overlap check, and does not pack as tightly. Further work.
    Changing paint color/alpha also not seem to work. Investigate.
```