### PR TITLE
Allow Type 14 charmap to fail in FT_Set_Charmap.

### DIFF
--- a/freetype/__init__.py
+++ b/freetype/__init__.py
@@ -1097,9 +1097,16 @@ class Face( object ):
         '''
         Select a given charmap for character code to glyph index mapping.
 
-        :param charmap: A handle to the selected charmap.
+        :param charmap: A handle to the selected charmap, or an index to face->charmaps[]
         '''
-        error = FT_Set_Charmap( self._FT_Face, charmap._FT_Charmap )
+        if ( type(charmap) == Charmap ):
+            error = FT_Set_Charmap( self._FT_Face, charmap._FT_Charmap )
+            # Type 14 is allowed to fail, to match ft2demo's behavior.
+            if ( charmap.cmap_format == 14 ):
+                error = 0
+        else:
+            # Treat "charmap" as plain number
+            error = FT_Set_Charmap( self._FT_Face, self._FT_Face.contents.charmaps[charmap] )
         if error : raise FT_Exception(error)
 
     def get_char_index( self, charcode ):


### PR DESCRIPTION
FT2 demo's ftdump ignores the return code of FT_Set_Charmap.

FT_Set_Charmap is known to fail when type~14 charmap is selected
(which doesn't map character codes to glyph indices at all).
This is a harmless situation. OpenType 1.8 fonts with Variations shows:

"format 14, platform 0, encoding  5   (Unicode Variation Sequences)"

An example is the Google Noto CJK /Adobe Source Sans fonts.

Also minor addition to API: auto-detect input type, and allow input as
integer index also.