### PR TITLE
Update the version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ Contributors
 """
 
 setup( name        = 'freetype-py',
-       version     = '1.0.2',
+       version     = '1.2',
        description = 'Freetype python bindings',
        long_description = description,
        author      = 'Nicolas P. Rougier',


### PR DESCRIPTION
When I tried to install 1.1 release I found its generating old 1.0.2 versioned egg-info directory. 
This pull-request will try to fix version in setup.py.
I have advanced the version to 1.2 so that you can release it directly after committing this patch.
Feel free to modify the patch if you want different version number.

Signed-off-by: Parag Nemade <pnemade@fedoraproject.org>