### PR TITLE
Avoid segfault on passing non-binary data to FT_Get_Name_Index

### DIFF
--- a/freetype/__init__.py
+++ b/freetype/__init__.py
@@ -1215,6 +1215,9 @@ class Face( object ):
 
         :param name: The glyph name.
         '''
+        if not isinstance(name, bytes):
+            raise FT_Exception(0x06, "FT_Get_Name_Index() expects a binary "
+                               "string for the name parameter.")
         return FT_Get_Name_Index( self._FT_Face, name )
 
     def set_transform( self, matrix, delta ):


### PR DESCRIPTION
I haven't looked at the source closely, but more functions may need a vetting.