### PR TITLE
fixed encoding error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,8 @@ from codecs import open
 from setuptools import setup, Extension
 
 description = open(path.join(path.abspath(path.dirname(__file__)),
-                             'README.rst')).read()
+                             'README.rst'),
+                   encoding="utf8").read()
 
 setup( name        = 'freetype-py',
        version     = '1.2',


### PR DESCRIPTION
Installation failed with this message:

```
Collecting freetype-py
  Downloading freetype-py-1.2.tar.gz (181kB)
    100% |████████████████████████████████| 184kB 1.6MB/s
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
<snip>
    UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in position 3934: character maps to <undefined>
```
