### PR TITLE
README.rst: fix invalid markup that fails to render on PyPI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,9 @@ system folder, you can choose one of the following ways to solve this:
 
 To get a complete list of all the directories in the $PATH
 environment variable (user and system), open a command promt and type
+
 .. code::
+
    echo %PATH%
 
 Usage example


### PR DESCRIPTION
Fixes #75 

I checked by installing `readme_renderer` and running `python setup.py check --restructuredtext --strict`