### PR TITLE
Expose FT_Outline_Decompose() as Outline.decompose(), with example

### DIFF
--- a/examples/glyph-vector-decompose.py
+++ b/examples/glyph-vector-decompose.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright 2018 Dean Serenevy <dean@serenevy.net>
+# SPDX-License-Identifier: BSD-3-Clause-Clear
+'''
+Show how to use outline decompose.
+'''
+import os
+import sys
+
+sys.path.append(os.path.dirname(__file__))
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+
+import freetype
+
+def move_to(a, ctx):
+    ctx.append("M {},{}".format(a.x, a.y))
+
+def line_to(a, ctx):
+    ctx.append("L {},{}".format(a.x, a.y))
+
+def conic_to(a, b, ctx):
+    ctx.append("Q {},{} {},{}".format(a.x, a.y, b.x, b.y))
+
+def cubic_to(a, b, c, ctx):
+    ctx.append("C {},{} {},{} {},{}".format(a.x, a.y, b.x, b.y, c.x, c.y))
+
+if __name__ == '__main__':
+    face = freetype.Face('./Vera.ttf')
+    face.set_char_size( 12*64 )
+    face.load_char('B')
+    ctx = []
+    face.glyph.outline.decompose(ctx, move_to=move_to, line_to=line_to, conic_to=conic_to, cubic_to=cubic_to)
+    print("""<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg">
+  <g>
+    <path
+      style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+      d="{}"
+    />
+  </g>
+</svg>
+""".format(" ".join(ctx)))

--- a/freetype/__init__.py
+++ b/freetype/__init__.py
@@ -654,6 +654,85 @@ class Outline( object ):
         FT_Outline_Get_CBox(byref(self._FT_Outline), byref(bbox))
         return BBox(bbox)
 
+    _od_move_to_noop = FT_Outline_MoveToFunc(lambda a, b: 0)
+    def _od_move_to_builder(self, cb):
+        if cb is None:
+            return self._od_move_to_noop
+        def move_to(a, b):
+            return cb(a[0], b) or 0
+        return FT_Outline_MoveToFunc(move_to)
+
+    _od_line_to_noop = FT_Outline_LineToFunc(lambda a, b: 0)
+    def _od_line_to_builder(self, cb):
+        if cb is None:
+            return self._od_line_to_noop
+        def line_to(a, b):
+            return cb(a[0], b) or 0
+        return FT_Outline_LineToFunc(line_to)
+
+    _od_conic_to_noop = FT_Outline_ConicToFunc(lambda a, b, c: 0)
+    def _od_conic_to_builder(self, cb):
+        if cb is None:
+            return self._od_conic_to_noop
+        def conic_to(a, b, c):
+            return cb(a[0], b[0], c) or 0
+        return FT_Outline_ConicToFunc(conic_to)
+
+    _od_cubic_to_noop = FT_Outline_CubicToFunc(lambda a, b, c, d: 0)
+    def _od_cubic_to_builder(self, cb):
+        if cb is None:
+            return self._od_cubic_to_noop
+        def cubic_to(a, b, c, d):
+            return cb(a[0], b[0], c[0], d) or 0
+        return FT_Outline_CubicToFunc(cubic_to)
+
+    def decompose(self, context=None, move_to=None, line_to=None, conic_to=None, cubic_to=None, shift=0, delta=0):
+        '''
+        Decompose the outline into a sequence of move, line, conic, and
+        cubic segments.
+
+        :param context: Arbitrary contextual object which will be passed as
+                        the last parameter of all callbacks. Typically an
+                        object to be drawn to, but can be anything.
+
+        :param move_to: Callback which will be passed an `FT_Vector`
+                        control point and the context. Called when outline
+                        needs to jump to a new path component.
+
+        :param line_to: Callback which will be passed an `FT_Vector`
+                        control point and the context. Called to draw a
+                        straight line from the current position to the
+                        control point.
+
+        :param conic_to: Callback which will be passed two `FT_Vector`
+                         control points and the context. Called to draw a
+                         second-order Bézier curve from the current
+                         position using the passed control points.
+
+        :param curve_to: Callback which will be passed three `FT_Vector`
+                         control points and the context. Called to draw a
+                         third-order Bézier curve from the current position
+                         using the passed control points.
+
+        :param shift: Passed to FreeType which will transform vectors via
+                      `x = (x << shift) - delta` and `y = (y << shift) - delta`
+
+        :param delta: Passed to FreeType which will transform vectors via
+                      `x = (x << shift) - delta` and `y = (y << shift) - delta`
+
+        :since: 1.3
+        '''
+        func = FT_Outline_Funcs(
+            move_to = self._od_move_to_builder(move_to),
+            line_to = self._od_line_to_builder(line_to),
+            conic_to = self._od_conic_to_builder(conic_to),
+            cubic_to = self._od_cubic_to_builder(cubic_to),
+            shift = shift,
+            delta = FT_Pos(delta),
+        )
+
+        error = FT_Outline_Decompose( byref(self._FT_Outline), byref(func), py_object(context) )
+        if error: raise FT_Exception( error )
 
 
 

--- a/freetype/ft_structs.py
+++ b/freetype/ft_structs.py
@@ -434,6 +434,47 @@ class FT_Outline(Structure):
         ('flags',      c_int),
     ]
 
+# -----------------------------------------------------------------------------
+# Callback functions used in FT_Outline_Funcs
+
+FT_Outline_MoveToFunc  = CFUNCTYPE(c_int, POINTER(FT_Vector), py_object)
+FT_Outline_LineToFunc  = CFUNCTYPE(c_int, POINTER(FT_Vector), py_object)
+FT_Outline_ConicToFunc = CFUNCTYPE(c_int, POINTER(FT_Vector), POINTER(FT_Vector), py_object)
+FT_Outline_CubicToFunc = CFUNCTYPE(c_int, POINTER(FT_Vector), POINTER(FT_Vector), POINTER(FT_Vector), py_object)
+
+# -----------------------------------------------------------------------------
+# Struct of callback functions for FT_Outline_Decompose()
+
+class FT_Outline_Funcs(Structure):
+    '''
+    This structure holds a set of callbacks which are called by
+    FT_Outline_Decompose.
+
+    move_to: Callback when outline needs to jump to a new path component.
+
+    line_to: Callback to draw a straight line from the current position to
+             the control point.
+
+    conic_to: Callback to draw a second-order Bézier curve from the current
+              position using the passed control points.
+
+    curve_to: Callback to draw a third-order Bézier curve from the current
+              position using the passed control points.
+
+    shift: Passed to FreeType which will transform vectors via
+           `x = (x << shift) - delta` and `y = (y << shift) - delta`
+
+    delta: Passed to FreeType which will transform vectors via
+           `x = (x << shift) - delta` and `y = (y << shift) - delta`
+    '''
+    _fields_ = [
+        ('move_to', FT_Outline_MoveToFunc),
+        ('line_to', FT_Outline_LineToFunc),
+        ('conic_to', FT_Outline_ConicToFunc),
+        ('cubic_to', FT_Outline_CubicToFunc),
+        ('shift', c_int),
+        ('delta', FT_Pos),
+    ]
 
 # -----------------------------------------------------------------------------
 # The root glyph structure contains a given glyph image plus its advance width


### PR DESCRIPTION
I wanted access to FT_Outline_Decompose(), so I added it in. See  examples/glyph-vector-decompose.py for example use.

I tried to follow existing conventions, I can fix things up if I made a blunder. Thanks for considering this PR!