### PR TITLE
Unbreak CI wheel building on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,11 +43,11 @@ matrix:
     - os: linux  # No bundling.
       env:
         - MB_PYTHON_VERSION=3.6
-        - USE_CCACHE=1
     - os: osx
       language: generic
       env:
         - MB_PYTHON_VERSION=3.6
+        - USE_CCACHE=1
         - FREETYPEPY_BUNDLE_FT=1
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,8 @@ matrix:
 before_install:
     - source ci/multibuild/common_utils.sh
     - source ci/multibuild/travis_steps.sh
+    # Pass FREETYPEPY_BUNDLE_FT environment variable to container.
+    - source ci/custom_docker.sh
     - before_install
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,13 +29,13 @@ matrix:
     # Exclude the default Python 3.5 build
     - python: 3.5
   include:
-    - os: linux
+    - os: linux  # Bundle 32 bit library. Python 2.7 just to test it works there.
       env:
         - MB_PYTHON_VERSION=2.7
         - PLAT=i686
         - USE_CCACHE=1
         - FREETYPEPY_BUNDLE_FT=1
-    - os: linux
+    - os: linux  # Bundle 64 bit library.
       env:
         - MB_PYTHON_VERSION=3.6
         - USE_CCACHE=1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,6 +60,7 @@ test_script:
 
   # run tests from installed wheel
   - cd tests
+  - python -c "import freetype; print('Using FreeType version ', freetype.version())"
   - pytest
 
 artifacts:

--- a/ci/custom_docker.sh
+++ b/ci/custom_docker.sh
@@ -1,0 +1,58 @@
+# Copy of upstream function with added FREETYPEPY_BUNDLE_FT environment var
+# passing.
+
+function build_multilinux {
+    # Runs passed build commands in manylinux container
+    #
+    # Depends on
+    #     MB_PYTHON_VERSION
+    #     UNICODE_WIDTH (optional)
+    #     BUILD_DEPENDS (optional)
+    #     DOCKER_IMAGE (optional)  
+    #     MANYLINUX_URL (optional)
+    #     WHEEL_SDIR (optional)
+    local plat=$1
+    [ -z "$plat" ] && echo "plat not defined" && exit 1
+    local build_cmds="$2"
+    local docker_image=${DOCKER_IMAGE:-quay.io/pypa/manylinux1_\$plat}
+    docker_image=$(eval echo "$docker_image")
+    retry docker pull $docker_image
+
+    if [ -n "$FREETYPEPY_BUNDLE_FT" ];
+        then
+            docker run --rm \
+                -e FREETYPEPY_BUNDLE_FT="1" \
+                -e BUILD_COMMANDS="$build_cmds" \
+                -e PYTHON_VERSION="$MB_PYTHON_VERSION" \
+                -e UNICODE_WIDTH="$UNICODE_WIDTH" \
+                -e BUILD_COMMIT="$BUILD_COMMIT" \
+                -e CONFIG_PATH="$CONFIG_PATH" \
+                -e ENV_VARS_PATH="$ENV_VARS_PATH" \
+                -e WHEEL_SDIR="$WHEEL_SDIR" \
+                -e MANYLINUX_URL="$MANYLINUX_URL" \
+                -e BUILD_DEPENDS="$BUILD_DEPENDS" \
+                -e USE_CCACHE="$USE_CCACHE" \
+                -e REPO_DIR="$repo_dir" \
+                -e PLAT="$PLAT" \
+                -v $PWD:/io \
+                -v $HOME:/parent-home \
+                $docker_image /io/$MULTIBUILD_DIR/docker_build_wrap.sh
+        else
+            docker run --rm \
+                -e BUILD_COMMANDS="$build_cmds" \
+                -e PYTHON_VERSION="$MB_PYTHON_VERSION" \
+                -e UNICODE_WIDTH="$UNICODE_WIDTH" \
+                -e BUILD_COMMIT="$BUILD_COMMIT" \
+                -e CONFIG_PATH="$CONFIG_PATH" \
+                -e ENV_VARS_PATH="$ENV_VARS_PATH" \
+                -e WHEEL_SDIR="$WHEEL_SDIR" \
+                -e MANYLINUX_URL="$MANYLINUX_URL" \
+                -e BUILD_DEPENDS="$BUILD_DEPENDS" \
+                -e USE_CCACHE="$USE_CCACHE" \
+                -e REPO_DIR="$repo_dir" \
+                -e PLAT="$PLAT" \
+                -v $PWD:/io \
+                -v $HOME:/parent-home \
+                $docker_image /io/$MULTIBUILD_DIR/docker_build_wrap.sh
+    fi
+}

--- a/ci/multibuild_config.sh
+++ b/ci/multibuild_config.sh
@@ -1,11 +1,13 @@
 # Define custom utilities
 # Test for OSX with [ -n "$IS_OSX" ]
 
-# function pre_build {
-#     # Any stuff that you need to do before you start building the wheels
-#     # Runs in the root directory of this repository.
-#
-# }
+function pre_build {
+    # Any stuff that you need to do before you start building the wheels
+    # Runs in the root directory of this repository.
+    if [ -z "$IS_OSX" ]; then
+        pip install cmake  # Version in manylinux1 container too old.
+    fi
+}
 
 function run_tests {
     # The function is called from an empty temporary directory.

--- a/setup-build-freetype.py
+++ b/setup-build-freetype.py
@@ -180,8 +180,9 @@ shell(
     cwd=build_dir_ft)
 shell("cmake --build . --config Release --target install", cwd=build_dir_ft)
 
-# Move libraries from PREFIX/bin to PREFIX/lib if need be (Windows DLLs are 
+# Move libraries from PREFIX/bin to PREFIX/lib if need be (Windows DLLs are
 # treated as runtimes and may end up in bin/). This keeps setup.py simple.
+target_dir = path.join(prefix_dir, "lib")
 bin_so = glob.glob(path.join(prefix_dir, "bin", "*freetype*"))
 bin_so.extend(glob.glob(path.join(prefix_dir, "lib64", "*freetype*")))
 bin_so.extend(glob.glob(path.join(prefix_dir, "lib", "freetype*.dll")))
@@ -189,6 +190,9 @@ for so in bin_so:
     so_target_name = path.basename(so)
     if not so_target_name.startswith("lib"):
         so_target_name = "lib" + so_target_name
-    lib_path = path.join(prefix_dir, "lib", so_target_name)
+    lib_path = path.join(target_dir, so_target_name)
+
     print("# Moving '{}' to '{}'".format(so, lib_path))
+    if not path.exists(target_dir):
+        os.makedirs(target_dir)
     os.rename(so, lib_path)

--- a/setup-build-freetype.py
+++ b/setup-build-freetype.py
@@ -70,7 +70,8 @@ if sys.platform == "darwin":
     bitness = 96
 
 if "linux" in sys.platform:
-    if os.environ.get("PYTHON_ARCH", "") == "32":
+    if (os.environ.get("PYTHON_ARCH", "") == "32"
+            or os.environ.get("PLAT", "") == "i686"):
         print("# Making a 32 bit build.")
         # On a 64 bit Debian/Ubuntu, this needs gcc-multilib and g++-multilib.
         # On a 64 bit Fedora, install glibc-devel and libstdc++-devel.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1


### PR DESCRIPTION
Edit: So, the 2.0 release was botched. The bundling didn't work on Linux because the FREETYPEPY_BUNDLE_FT variable didn't reach the Docker container. This PR makes it work. AppVeyor deployment may need a separate fix.