### PR TITLE
Fix AppVeyor deployment script and add sdist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,8 @@ before_install:
 
 install:
     - build_wheel $REPO_DIR $PLAT
+    # Additionally build sdist on tag and not bundling.
+    - if [ -z $"FREETYPEPY_BUNDLE_FT" && -n "$TRAVIS_TAG" ]; then python setup.py sdist; fi
 
 script:
     - install_run $PLAT

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -68,14 +68,11 @@ artifacts:
   - path: dist\*.whl
 
 on_success:
- # deploy wheels on tags to PyPI
- - ps: >-
-     if($env:APPVEYOR_REPO_TAG -eq 'true') {
-       Write-Output ("Deploying " + $env:APPVEYOR_REPO_TAG_NAME + " to PyPI...")
-       pip install --upgrade twine
-       # If powershell ever sees anything on stderr it thinks it's a fail.
-       # So we use cmd to redirect stderr to stdout before PS can see it.
-       cmd /c 'twine upload dist\*.whl 2>&1'
-     } else {
-       Write-Output "Not deploying as this is not a tagged commit"
-     }
+  - ps: >-
+      if ($env:APPVEYOR_REPO_TAG -eq 'true') {
+        Write-Output ("Deploying " + $env:APPVEYOR_REPO_TAG_NAME + " to PyPI...")
+        pip install --upgrade twine
+        twine upload wheelhouse\*.whl
+      } else {
+        Write-Output "Not deploying as this is not a tagged commit"
+      }


### PR DESCRIPTION
cmd.exe doesn't expand *.whl and newer twine versions work better with PowerShell, so get rid of the hack.

Also generate sdist on deploy.