### PR TITLE
Fix bug where outline and bitmap could be off by one grid unit in the…

### DIFF
--- a/examples/glyph-vector-2-cairo.py
+++ b/examples/glyph-vector-2-cairo.py
@@ -47,7 +47,7 @@ if __name__ == '__main__':
     points = numpy.array(outline.points, dtype=[('x',float), ('y',float)])
     x, y = points['x'], points['y']
 
-    bbox = outline.get_bbox()
+    bbox = outline.get_cbox()
 
     MARGIN  = 10
     scale = 3


### PR DESCRIPTION
… example.

In simple glyphs and well-behaving glyphs, the bbox and cbox are virtually
identical - in fact fontforge's "addExtrema()" function does exactly that.

Glyphs in CJK fonts are often large enough and cannot afford the extra control
points at extremities, so don't. It is possible to have off-contour control
point(s) and the actual contour on opposite side of a pixel boundary in either
the horizontal edges or vertical edges. The pixel-fitted control box
is larger than the bound box by one in these cases.

Encountered this bug when trying to draw my own name in Chinese with msmincho
at 15pt.

Good side-effect is that this example supposedly runs faster - cbox is faster
than bbox.