### PR TITLE
Implement Face loading from memory

### DIFF
--- a/freetype/__init__.py
+++ b/freetype/__init__.py
@@ -966,7 +966,7 @@ class Face( object ):
         '''
         Build a new Face
 
-        :param Union[str, io.BytesIO] path_or_stream:
+        :param Union[str, typing.BinaryIO] path_or_stream:
             A path to the font file or an io.BytesIO stream.
 
         :param int index:
@@ -989,7 +989,6 @@ class Face( object ):
                 error = self._init_from_memory(library, face, index, filebody)
         if error:
             raise FT_Exception(error)
-        self._filename = path_or_stream
         self._index = index
         self._FT_Face = face
 
@@ -1006,7 +1005,7 @@ class Face( object ):
         return error
 
     @classmethod
-    def from_memory(cls, bytes_, index=0):
+    def from_bytes(cls, bytes_, index=0):
          return cls(io.BytesIO(bytes_), index)
 
     def __del__( self ):

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -17,7 +17,7 @@ def test_load_ft_face_from_memory():
 
     with open("../examples/Vera.ttf", mode="rb") as f:
         byte_stream = f.read()
-    assert freetype.Face.from_memory(byte_stream)
+    assert freetype.Face.from_bytes(byte_stream)
 
 
 def test_bundle_version():

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -7,7 +7,17 @@ import pytest
 
 def test_load_ft_face():
     """A smoke test."""
-    assert freetype.Face('../examples/Vera.ttf')
+    assert freetype.Face("../examples/Vera.ttf")
+
+
+def test_load_ft_face_from_memory():
+    """Another smoke test."""
+    with open("../examples/Vera.ttf", mode="rb") as f:
+        assert freetype.Face(f)
+
+    with open("../examples/Vera.ttf", mode="rb") as f:
+        byte_stream = f.read()
+    assert freetype.Face.from_memory(byte_stream)
 
 
 def test_bundle_version():


### PR DESCRIPTION
The fourth PR to tackle loading a font from memory instead of from disk. 

- Since we still have to support Python 2(?), testing the `file_or_stream` argument for being a `bytes` object won't work, accept a `io.BytesIO` object instead.
- Implement @rougier's suggestion at https://github.com/rougier/freetype-py/pull/33#issuecomment-167834852. Since loading from a path is the default, I did not add a `from_file` class method. It would make more sense when `Face::__init__` is refactored to not have any logic and just stores what it's given.

Not sure what to do about `Face::_filename`. it doesn't seem to be used anywhere.

Working on `attach_file`, I need a test case.

Closes https://github.com/rougier/freetype-py/pull/33, https://github.com/rougier/freetype-py/pull/103, https://github.com/rougier/freetype-py/pull/104