### PR TITLE
Remove Python 3.7 from CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
         - PLAT=i686
         - USE_CCACHE=1
         - FREETYPEPY_BUNDLE_FT=1
-    - os: linux  # Bundle 64 bit library for Python 3.6.
+    - os: linux  # Bundle 64 bit library.
       env:
         - MB_PYTHON_VERSION=3.6
         - USE_CCACHE=1
@@ -47,17 +47,6 @@ matrix:
       language: generic
       env:
         - MB_PYTHON_VERSION=3.6
-        - USE_CCACHE=1
-        - FREETYPEPY_BUNDLE_FT=1
-    - os: linux  # Bundle 64 bit library for Python 3.7.
-      env:
-        - MB_PYTHON_VERSION=3.7
-        - USE_CCACHE=1
-        - FREETYPEPY_BUNDLE_FT=1
-    - os: osx
-      language: generic
-      env:
-        - MB_PYTHON_VERSION=3.7
         - USE_CCACHE=1
         - FREETYPEPY_BUNDLE_FT=1
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,10 +15,6 @@ environment:
       PYTHON_VERSION: 3.6
       PYTHON_ARCH: '64'
 
-    - PYTHON: C:\Python36-x64
-      PYTHON_VERSION: 3.7
-      PYTHON_ARCH: '64'
-
 init:
   - ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%
 


### PR DESCRIPTION
The packages for 3.6 are universal because we don't depend on CPython internals. Duh.