### PR TITLE
Fix bbox calculation in hello-world example

### DIFF
--- a/examples/hello-world.py
+++ b/examples/hello-world.py
@@ -13,14 +13,15 @@ if __name__ == '__main__':
     import matplotlib.pyplot as plt
 
     face = Face('./Vera.ttf')
-    text = 'Hello World, !'
-    face.set_char_size( 48*64 )
+    text = 'Hello World !'
+    fontsize = 48
+    face.set_char_size( fontsize*64 )
     slot = face.glyph
 
     # First pass to compute bbox
     width = 0
-    top = -32768
-    bot = 32767
+    top = -fontsize #The distance from baseline to the top row of the bbox
+    bot = fontsize #The distance from baseline to the bottom row of the bbox (may be negative)
     previous = 0
     for i,c in enumerate(text):
         face.load_char(c)


### PR DESCRIPTION
If the string contains a ',' the example code produces the following error:
```
Traceback (most recent call last):
  File "hello-world.py", line 47, in <module>
    Z[y:y+h,x:x+w] += numpy.array(bitmap.buffer, dtype='ubyte').reshape(h,w)
ValueError: operands could not be broadcast together with shapes (0,28) (35,28) (0,28)
```
If the string in the hello-world example contains some characters which passes the baseline the bbox calculation fails. This will be the case when a ',' is added to the example string.
