### PR TITLE
setup.py: no need to specifiy toml extra in setup_requires

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         fetch-depth: 0  # unshallow fetch for setuptools-scm
 
     - name: Use MSBuild (Windows)
-      uses: microsoft/setup-msbuild@v1.0.0
+      uses: microsoft/setup-msbuild@v1.0.2
       if: matrix.os == 'windows-latest'
 
     - uses: actions/setup-python@v1

--- a/setup.py
+++ b/setup.py
@@ -127,5 +127,5 @@ setup(
         'Topic :: Multimedia :: Graphics',
     ],
     keywords=['freetype', 'font'],
-    setup_requires=['setuptools_scm[toml]'],
+    setup_requires=['setuptools_scm'],
 )


### PR DESCRIPTION
follows recommendation in https://github.com/pypa/setuptools_scm#pyprojecttoml-usage

Fixes https://github.com/rougier/freetype-py/issues/128

