### PR TITLE
support for ARM builds

### DIFF
--- a/setup-build-freetype.py
+++ b/setup-build-freetype.py
@@ -81,10 +81,7 @@ if sys.platform == "darwin":
 if "linux" in sys.platform:
     c_flags = cxx_flags = "-O2"
     ld_flags = ""
-    if (
-        platform.machine() == "x86_64"
-        or platform.machine() == "x86"
-    ):
+    if platform.machine() == "x86_64":
         if (
             os.environ.get("PYTHON_ARCH", "") == "32"
             or platform.architecture() == "32bit"

--- a/setup-build-freetype.py
+++ b/setup-build-freetype.py
@@ -21,6 +21,7 @@ import tarfile
 import urllib
 from os import path
 from urllib.request import urlopen
+import platform
 
 # Needed for the GitHub Actions macOS CI runner, which appears to come without CAs.
 import certifi
@@ -78,27 +79,38 @@ if sys.platform == "darwin":
     bitness = 64
 
 if "linux" in sys.platform:
-    if (
-        os.environ.get("PYTHON_ARCH", "") == "32"
-        or os.environ.get("PLAT", "") == "i686"
-    ):
-        print("# Making a 32 bit build.")
-        # On a 64 bit Debian/Ubuntu, this needs gcc-multilib and g++-multilib.
-        # On a 64 bit Fedora, install glibc-devel and libstdc++-devel.
-        CMAKE_GLOBAL_SWITCHES += (
-            '-DCMAKE_C_FLAGS="-m32 -O2" '
-            '-DCMAKE_CXX_FLAGS="-m32 -O2" '
-            '-DCMAKE_LD_FLAGS="-m32" '
-        )
-        bitness = 32
+    c_flags = cxx_flags = "-O2"
+    ld_flags = ""
+    if ("arm" not in platform.machine() and 
+            platform.machine() != "aarch64"):
+        if (
+            os.environ.get("PYTHON_ARCH", "") == "32"
+            or platform.architecture() == "32bit"
+        ):
+            print("# Making a 32 bit build.")
+            # On a 64 bit Debian/Ubuntu, this needs gcc-multilib and g++-multilib.
+            # On a 64 bit Fedora, install glibc-devel and libstdc++-devel.
+            c_flags = "-m32 {}".format(c_flags)
+            cxx_flags = "-m32 {}".format(cxx_flags)
+            ld_flags = "-m32"
+            bitness = 32
+        else:
+            print("# Making a 64 bit build.")
+            c_flags = "-m64 {}".format(c_flags)
+            cxx_flags = "-m64 {}".format(cxx_flags)
+            ld_flags = "-m64"
+            bitness = 64
     else:
-        print("# Making a 64 bit build.")
-        CMAKE_GLOBAL_SWITCHES += (
-            '-DCMAKE_C_FLAGS="-m64 -O2" '
-            '-DCMAKE_CXX_FLAGS="-m64 -O2" '
-            '-DCMAKE_LD_FLAGS="-m64" '
-        )
-        bitness = 64
+        print("# Making an {} build.".format(platform.machine()))
+        if platform.architecture() == "32bit":
+            bitness = 32
+        else:
+            bitness = 64
+    CMAKE_GLOBAL_SWITCHES += (
+        '-DCMAKE_C_FLAGS="{}" '.format(c_flags) +
+        '-DCMAKE_CXX_FLAGS="{}" '.format(cxx_flags) +
+        '-DCMAKE_LD_FLAGS="{}" '.format(ld_flags)
+    )
 
 
 def shell(cmd, cwd=None):

--- a/setup-build-freetype.py
+++ b/setup-build-freetype.py
@@ -81,8 +81,10 @@ if sys.platform == "darwin":
 if "linux" in sys.platform:
     c_flags = cxx_flags = "-O2"
     ld_flags = ""
-    if ("arm" not in platform.machine() and 
-            platform.machine() != "aarch64"):
+    if (
+        platform.machine == "x86_64"
+        or platform.machine == "x86"
+    ):
         if (
             os.environ.get("PYTHON_ARCH", "") == "32"
             or platform.architecture() == "32bit"
@@ -101,7 +103,7 @@ if "linux" in sys.platform:
             ld_flags = "-m64"
             bitness = 64
     else:
-        print("# Making an {} build.".format(platform.machine()))
+        print("# Making a '{}' build.".format(platform.machine()))
         if platform.architecture() == "32bit":
             bitness = 32
         else:

--- a/setup-build-freetype.py
+++ b/setup-build-freetype.py
@@ -82,8 +82,8 @@ if "linux" in sys.platform:
     c_flags = cxx_flags = "-O2"
     ld_flags = ""
     if (
-        platform.machine == "x86_64"
-        or platform.machine == "x86"
+        platform.machine() == "x86_64"
+        or platform.machine() == "x86"
     ):
         if (
             os.environ.get("PYTHON_ARCH", "") == "32"


### PR DESCRIPTION
Hello,

during the build process on a Raspberry Pi I got an error from cmake, that the `-m32` or `-m64` flag is not supported on this platform.

So I reworked the code to detect not only if the system is 32/64bit but also if it's an ARM system. There's also support for `aarch64`.