### PR TITLE
Add arm64 to build matrix and update cibuildwheel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,54 +13,66 @@ on:
 
 jobs:
   build:
-    name: Build wheels on ${{ matrix.os }}
+    name: Build wheels on ${{ matrix.os }} ${{ matrix.name }}
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-
+        include:
+        - os: ubuntu-latest
+          cibw_build: "cp36-*"
+        - os: windows-latest
+          cibw_build: "cp36-*"
+        - os: macos-latest
+          cibw_build: "cp36-*"
+        - os: macos-latest
+          cibw_build: "cp38-macosx_arm64"
+          name: '(arm64)'
+        - os: macos-latest
+          cibw_build: "cp38-macosx_universal2"
+          name: '(universal2)'
     steps:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0  # unshallow fetch for setuptools-scm
 
-    - name: Use MSBuild (Windows)
-      uses: microsoft/setup-msbuild@v1.0.2
-      if: matrix.os == 'windows-latest'
-
-    - uses: actions/setup-python@v1
-      name: Install Python
-      with:
-        python-version: '3.6'
-
-    - name: Install cibuildwheel
-      run: |
-        python -m pip install cibuildwheel==1.5.2
-
-    - name: Build wheel
-      run: |
-        python -m cibuildwheel --output-dir dist
+    - name: Build wheels
+      uses: pypa/cibuildwheel@v2.2.2
       env:
-        # The packaged FreeType library is independent of the Python ABI so we only
-        # need to build it once.
-        CIBW_BUILD: "cp36-*x86_64 cp36-*amd64"
+        CIBW_BUILD: ${{ matrix.cibw_build }}
+        CIBW_ARCHS: "auto64"
+        CIBW_ARCHS_MACOS: "auto64 universal2 arm64"
         CIBW_ENVIRONMENT: "FREETYPEPY_BUNDLE_FT=yes PYTHON_ARCH=64"
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
         CIBW_TEST_COMMAND: "pytest {project}/tests"
         CIBW_TEST_REQUIRES: "pytest"
-
-    - uses: actions/upload-artifact@v2
       with:
-        name: freetype-py-dist
-        path: dist/*.whl
+        output-dir: dist
 
-    # Build sdist on one platform, and only on tagged commits.
+    - name: Upload distributions
+      uses: actions/upload-artifact@v2
+      with:
+        path: dist
+        name: dist
+
+  publish:
+    name: Publish release to Pypi
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: success() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
+    - name: Download assets
+      uses: actions/download-artifact@v1.0.0
+      with:
+        name: dist
     - name: Build sdist
       run: |
         python setup.py sdist
-      if: matrix.os == 'ubuntu-latest' && github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
-
     - name: Publish package to PyPI
       run: |
         pip install twine
@@ -68,4 +80,3 @@ jobs:
       env:
         TWINE_USERNAME: ${{ secrets.pypi_username }}
         TWINE_PASSWORD: ${{ secrets.pypi_password }}
-      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,8 @@ jobs:
     if: success() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0  # unshallow fetch for setuptools-scm
     - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:


### PR DESCRIPTION
Closes #138

* This upgrades CI to use the latest version of cibuildwheel and adds apple silicon wheels to the build configuration.
* Apple silicon wheels can only be built for python >=3.8.
* This newer version of cibuildwheel also happens to build musllinux wheels, so that's a free bonus, I guess!
* Split out the publish to pypi job