### PR TITLE
Add aarch64 builds to build matrix and update cibuildwheel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,31 +29,30 @@ jobs:
       uses: microsoft/setup-msbuild@v1.0.2
       if: matrix.os == 'windows-latest'
 
-    - uses: actions/setup-python@v1
-      name: Install Python
-      with:
-        python-version: '3.6'
-
-    - name: Install cibuildwheel
-      run: |
-        python -m pip install cibuildwheel==1.5.2
-
-    - name: Build wheel
-      run: |
-        python -m cibuildwheel --output-dir dist
+    - name: Build wheels
+      uses: pypa/cibuildwheel@v2.2.2
       env:
         # The packaged FreeType library is independent of the Python ABI so we only
         # need to build it once.
-        CIBW_BUILD: "cp36-*x86_64 cp36-*amd64"
+        CIBW_BUILD: "cp39-*"
+        CIBW_ARCHS: "auto64"
+        CIBW_ARCHS_MACOS: "auto64 universal2 arm64"
         CIBW_ENVIRONMENT: "FREETYPEPY_BUNDLE_FT=yes PYTHON_ARCH=64"
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
         CIBW_TEST_COMMAND: "pytest {project}/tests"
         CIBW_TEST_REQUIRES: "pytest"
+      with:
+        output-dir: dist
 
     - uses: actions/upload-artifact@v2
       with:
         name: freetype-py-dist
         path: dist/*.whl
+
+    - uses: actions/setup-python@v1
+      name: Install Python
+      with:
+        python-version: '3.9'
 
     # Build sdist on one platform, and only on tagged commits.
     - name: Build sdist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,12 @@ jobs:
           name: '(manylinux aarch64)'
           archs_linux: 'aarch64'
           skip: '*musllinux*'
+          qemu: true
         - os: 'ubuntu-latest'
           name: '(musllinux aarch64)'
           archs_linux: 'aarch64'
           skip: '*manylinux*'
+          qemu: true
 
     steps:
     - uses: actions/checkout@v2
@@ -38,7 +40,7 @@ jobs:
         fetch-depth: 0  # unshallow fetch for setuptools-scm
 
     - name: Set up QEMU
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.qemu
       uses: docker/setup-qemu-action@v1
       with:
         platforms: all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,21 +13,35 @@ on:
 
 jobs:
   build:
-    name: Build wheels on ${{ matrix.os }}
+    name: Build wheels on ${{ matrix.os }} ${{ matrix.name }}
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        include:
+        - os: 'windows-latest'
+        - os: 'macos-latest'
+        - os: 'ubuntu-latest'
+          archs_linux: "auto64"
+        - os: 'ubuntu-latest'
+          name: '(manylinux aarch64)'
+          archs_linux: 'aarch64'
+          skip: '*musllinux*'
+        - os: 'ubuntu-latest'
+          name: '(musllinux aarch64)'
+          archs_linux: 'aarch64'
+          skip: '*manylinux*'
 
     steps:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0  # unshallow fetch for setuptools-scm
 
-    - name: Use MSBuild (Windows)
-      uses: microsoft/setup-msbuild@v1.0.2
-      if: matrix.os == 'windows-latest'
+    - name: Set up QEMU
+      if: matrix.os == 'ubuntu-latest'
+      uses: docker/setup-qemu-action@v1
+      with:
+        platforms: all
 
     - name: Build wheels
       uses: pypa/cibuildwheel@v2.2.2
@@ -35,8 +49,10 @@ jobs:
         # The packaged FreeType library is independent of the Python ABI so we only
         # need to build it once.
         CIBW_BUILD: "cp39-*"
+        CIBW_SKIP: ${{ matrix.skip }}
         CIBW_ARCHS: "auto64"
         CIBW_ARCHS_MACOS: "auto64 universal2 arm64"
+        CIBW_ARCHS_LINUX: ${{ matrix.archs_linux }}
         CIBW_ENVIRONMENT: "FREETYPEPY_BUNDLE_FT=yes PYTHON_ARCH=64"
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
         CIBW_TEST_COMMAND: "pytest {project}/tests"
@@ -53,6 +69,7 @@ jobs:
       name: Install Python
       with:
         python-version: '3.9'
+      if: matrix.os == 'ubuntu-latest' && github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
 
     # Build sdist on one platform, and only on tagged commits.
     - name: Build sdist


### PR DESCRIPTION
Depends on #139 

This adds aarch64 builds for manylinux and musllinux using QEMU. That makes the wheel installable on e.g. raspberry pi.

I reconfigured the build matrix to run these builds in parallel as they are quite slow.

I figured I would just open the PR as it was relatively easy to configure, leaving it to you to decide if you want to have this change merged or not. The argument against slow CI is quite clear and it doesn't look like I can make it any faster.