### PR TITLE
Add support for SDF rendering.

### DIFF
--- a/freetype/__init__.py
+++ b/freetype/__init__.py
@@ -975,6 +975,98 @@ class GlyphSlot( object ):
           glyph: valid FT_GlyphSlot object
         '''
         self._FT_GlyphSlot = slot
+        
+    def render( self, render_mode ):
+        '''
+        Convert a given glyph image to a bitmap. It does so by inspecting the
+        glyph image format, finding the relevant renderer, and invoking it.
+        
+        :param render_mode: The render mode used to render the glyph image into
+                            a bitmap. See FT_Render_Mode for a list of possible
+                            values.
+                            
+                            If FT_RENDER_MODE_NORMAL is used, a previous call
+                            of FT_Load_Glyph with flag FT_LOAD_COLOR makes
+                            FT_Render_Glyph provide a default blending of
+                            colored glyph layers associated with the current
+                            glyph slot (provided the font contains such layers)
+                            instead of rendering the glyph slot's outline.
+                            This is an experimental feature; see FT_LOAD_COLOR
+                            for more information.
+                            
+        **Note**:
+        
+          To get meaningful results, font scaling values must be set with
+          functions like FT_Set_Char_Size before calling FT_Render_Glyph.
+
+          When FreeType outputs a bitmap of a glyph, it really outputs an alpha
+          coverage map. If a pixel is completely covered by a filled-in
+          outline, the bitmap contains 0xFF at that pixel, meaning that
+          0xFF/0xFF fraction of that pixel is covered, meaning the pixel is
+          100% black (or 0% bright). If a pixel is only 50% covered
+          (value 0x80), the pixel is made 50% black (50% bright or a middle
+          shade of grey). 0% covered means 0% black (100% bright or white).
+
+          On high-DPI screens like on smartphones and tablets, the pixels are
+          so small that their chance of being completely covered and therefore
+          completely black are fairly good. On the low-DPI screens, however,
+          the situation is different. The pixels are too large for most of the
+          details of a glyph and shades of gray are the norm rather than the
+          exception.
+
+          This is relevant because all our screens have a second problem: they
+          are not linear. 1 + 1 is not 2. Twice the value does not result in
+          twice the brightness. When a pixel is only 50% covered, the coverage
+          map says 50% black, and this translates to a pixel value of 128 when
+          you use 8 bits per channel (0-255). However, this does not translate
+          to 50% brightness for that pixel on our sRGB and gamma 2.2 screens.
+          Due to their non-linearity, they dwell longer in the darks and only a
+          pixel value of about 186 results in 50% brightness – 128 ends up too
+          dark on both bright and dark backgrounds. The net result is that dark
+          text looks burnt-out, pixely and blotchy on bright background, bright
+          text too frail on dark backgrounds, and colored text on colored
+          background (for example, red on green) seems to have dark halos or
+          ‘dirt’ around it. The situation is especially ugly for diagonal stems
+          like in ‘w’ glyph shapes where the quality of FreeType's
+          anti-aliasing depends on the correct display of grays. On high-DPI
+          screens where smaller, fully black pixels reign supreme, this doesn't
+          matter, but on our low-DPI screens with all the gray shades, it does.
+          0% and 100% brightness are the same things in linear and non-linear
+          space, just all the shades in-between aren't.
+
+          The blending function for placing text over a background is
+
+          dst = alpha * src + (1 - alpha) * dst
+
+          which is known as the OVER operator.
+
+          To correctly composite an anti-aliased pixel of a glyph onto a
+          surface, take the foreground and background colors (e.g., in sRGB
+          space) and apply gamma to get them in a linear space, use OVER to
+          blend the two linear colors using the glyph pixel as the alpha value
+          (remember, the glyph bitmap is an alpha coverage bitmap), and apply
+          inverse gamma to the blended pixel and write it back to the image.
+
+          Internal testing at Adobe found that a target inverse gamma of 1.8
+          for step 3 gives good results across a wide range of displays with
+          an sRGB gamma curve or a similar one.
+
+          This process can cost performance. There is an approximation that
+          does not need to know about the background color; see
+          https://bel.fi/alankila/lcd/ and
+          https://bel.fi/alankila/lcd/alpcor.html for details.
+
+          **ATTENTION:** Linear blending is even more important when dealing
+          with subpixel-rendered glyphs to prevent color-fringing! A
+          subpixel-rendered glyph must first be filtered with a filter that
+          gives equal weight to the three color primaries and does not exceed a
+          sum of 0x100, see section ‘Subpixel Rendering’. Then the only
+          difference to gray linear blending is that subpixel-rendered linear
+          blending is done 3 times per pixel: red foreground subpixel to red
+          background subpixel and so on for green and blue.
+        '''
+        error = FT_Render_Glyph( self._FT_GlyphSlot, render_mode )
+        if error: raise FT_Exception( error )
 
     def get_glyph( self ):
         '''

--- a/freetype/ft_enums/ft_render_modes.py
+++ b/freetype/ft_enums/ft_render_modes.py
@@ -47,10 +47,20 @@ FT_RENDER_MODE_LCD_V
   screens, rotated LCD displays, etc.). It produces 8-bit bitmaps that are 3
   times the height of the original glyph outline in pixels and use the
   FT_PIXEL_MODE_LCD_V mode.
+  
+FT_RENDER_MODE_SDF
+
+  This mode corresponds to 8-bit, single-channel signed distance field (SDF)
+  bitmaps. Each pixel in the SDF grid is the value from the pixel's position to
+  the nearest glyph's outline. The distances are calculated from the center of
+  the pixel and are positive if they are filled by the outline (i.e., inside
+  the outline) and negative otherwise. Check the note below on how to convert
+  the output values to usable data.
 """
 FT_RENDER_MODES = { 'FT_RENDER_MODE_NORMAL' : 0,
                     'FT_RENDER_MODE_LIGHT'  : 1,
                     'FT_RENDER_MODE_MONO'   : 2,
                     'FT_RENDER_MODE_LCD'    : 3,
-                    'FT_RENDER_MODE_LCD_V'  : 4 }
+                    'FT_RENDER_MODE_LCD_V'  : 4,
+                    'FT_RENDER_MODE_SDF'    : 5 }
 globals().update(FT_RENDER_MODES)

--- a/freetype/raw.py
+++ b/freetype/raw.py
@@ -277,6 +277,7 @@ FT_Outline_Reverse             = _lib.FT_Outline_Reverse
 FT_Outline_Transform           = _lib.FT_Outline_Transform
 FT_Outline_Translate           = _lib.FT_Outline_Translate
 FT_Remove_Module               = _lib.FT_Remove_Module
+FT_Render_Glyph                = _lib.FT_Render_Glyph
 FT_RoundFix                    = _lib.FT_RoundFix
 FT_Set_Debug_Hook              = _lib.FT_Set_Debug_Hook
 FT_Set_MM_Blend_Coordinates    = _lib.FT_Set_MM_Blend_Coordinates

--- a/setup-build-freetype.py
+++ b/setup-build-freetype.py
@@ -27,9 +27,9 @@ import platform
 import certifi
 
 FREETYPE_HOST = "https://download.savannah.gnu.org/releases/freetype/"
-FREETYPE_TARBALL = "freetype-2.10.2.tar.xz"
+FREETYPE_TARBALL = "freetype-2.11.0.tar.xz"
 FREETYPE_URL = FREETYPE_HOST + FREETYPE_TARBALL
-FREETYPE_SHA256 = "1543d61025d2e6312e0a1c563652555f17378a204a61e99928c9fcef030a2d8b"
+FREETYPE_SHA256 = "8bee39bd3968c4804b70614a0a3ad597299ad0e824bc8aad5ce8aaf48067bde7"
 HARFBUZZ_HOST = "https://www.freedesktop.org/software/harfbuzz/release/"
 HARFBUZZ_TARBALL = "harfbuzz-2.6.7.tar.xz"
 HARFBUZZ_URL = HARFBUZZ_HOST + HARFBUZZ_TARBALL


### PR DESCRIPTION
- Ups the freetype version to 2.11
- Adds the `FT_RENDER_MODE_SDF` flag
- Adds the `render` method to `GlyphSlot` corresponding to `FT_Render_Glyph`

There is no `FT_LOAD_TARGET_XXX` for SDF, so an api for `FT_Render_Glyph` is required to render an SDF. Not sure if this is an oversight in the freetype API or by design.