### PR TITLE
Fix bindings for FT_Outline

### DIFF
--- a/examples/outline-test.py
+++ b/examples/outline-test.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+#
+#  FreeType high-level python API - Copyright 2011-2015 Nicolas P. Rougier
+#  Distributed under the terms of the new BSD license.
+#
+# -----------------------------------------------------------------------------
+'''
+Basic outline wrapper test
+'''
+from freetype import *
+import ctypes
+import contextlib
+
+@contextlib.contextmanager
+def new_outline(n_points, n_contours):
+    library = get_handle()
+    raw_ft_outline = FT_Outline()
+    err = FT_Outline_New(
+        library, FT_UInt(n_points), FT_Int(n_contours),
+        ctypes.byref(raw_ft_outline)
+    )
+    if err: raise FT_Exception(error)
+    try:
+        raw_ft_outline.n_points   = 0
+        raw_ft_outline.n_contours = 0
+        yield Outline(raw_ft_outline)
+    finally:
+        FT_Outline_Done(library, ctypes.byref(raw_ft_outline))
+
+if __name__ == '__main__':
+    face = Face('./Vera.ttf')
+    face.set_char_size( 4*48*64 )
+    flags = FT_LOAD_DEFAULT | FT_LOAD_NO_BITMAP
+    face.load_char('S', flags )
+    slot = face.glyph
+    outline = slot.outline
+
+    bbox = outline.get_bbox()
+    cbox = outline.get_cbox()
+    assert (bbox.xMin, bbox.yMin, bbox.xMax, bbox.yMax) == \
+        (810, -192, 7116, 9152)
+    assert (cbox.xMin, cbox.yMin, cbox.xMax, cbox.yMax) == \
+        (810, -192, 7116, 9152)
+    assert outline.get_outside_border() == 0
+    assert outline.get_inside_border() == 1
+    assert len(outline.contours) == 1
+    assert len(outline.points) == 40
+    assert len(outline.tags) == 40
+
+    stroker = Stroker()
+    stroker.set(64, FT_STROKER_LINECAP_ROUND, FT_STROKER_LINEJOIN_ROUND, 0)
+    stroker.parse_outline(outline, False)
+
+    n_points, n_contours = stroker.get_counts()
+    with new_outline(n_points, n_contours) as stroked_outline:
+        stroker.export(stroked_outline)
+        bbox = stroked_outline.get_bbox()
+        cbox = stroked_outline.get_cbox()
+        assert (bbox.xMin, bbox.yMin, bbox.xMax, bbox.yMax) == \
+            (746, -256, 7180, 9216)
+        assert (cbox.xMin, cbox.yMin, cbox.xMax, cbox.yMax) == \
+            (746, -256, 7180, 9216)
+        assert stroked_outline.get_outside_border() == 0
+        assert stroked_outline.get_inside_border() == 1
+        assert len(stroked_outline.contours) == 2
+        assert len(stroked_outline.points) == 225
+        assert len(stroked_outline.tags) == 225
+
+    border = outline.get_outside_border()
+    n_points, n_contours = stroker.get_border_counts(border)
+    with new_outline(n_points, n_contours) as outer_outline:
+        stroker.export_border(border, outer_outline)
+        bbox = outer_outline.get_bbox()
+        cbox = outer_outline.get_cbox()
+        assert (bbox.xMin, bbox.yMin, bbox.xMax, bbox.yMax) == \
+            (746, -256, 7180, 9216)
+        assert (cbox.xMin, cbox.yMin, cbox.xMax, cbox.yMax) == \
+            (746, -256, 7180, 9216)
+        assert outer_outline.get_outside_border() == 0
+        assert outer_outline.get_inside_border() == 1
+        assert len(outer_outline.contours) == 1
+        assert len(outer_outline.points) == 121
+        assert len(outer_outline.tags) == 121
+
+    border = outline.get_inside_border()
+    n_points, n_contours = stroker.get_border_counts(border)
+    with new_outline(n_points, n_contours) as inner_outline:
+        stroker.export_border(border, inner_outline)
+        bbox = inner_outline.get_bbox()
+        cbox = inner_outline.get_cbox()
+        assert (bbox.xMin, bbox.yMin, bbox.xMax, bbox.yMax) == \
+            (813, -128, 7052, 9088)
+        assert (cbox.xMin, cbox.yMin, cbox.xMax, cbox.yMax) == \
+            (813, -128, 7052, 9088)
+        assert inner_outline.get_outside_border() == 1
+        assert inner_outline.get_inside_border() == 0
+        assert len(inner_outline.contours) == 1
+        assert len(inner_outline.points) == 104
+        assert len(inner_outline.tags) == 104

--- a/examples/outline-test.py
+++ b/examples/outline-test.py
@@ -21,7 +21,7 @@ def new_outline(n_points, n_contours):
         library, FT_UInt(n_points), FT_Int(n_contours),
         ctypes.byref(raw_ft_outline)
     )
-    if err: raise FT_Exception(error)
+    if err: raise FT_Exception(err)
     try:
         raw_ft_outline.n_points   = 0
         raw_ft_outline.n_contours = 0

--- a/freetype/__init__.py
+++ b/freetype/__init__.py
@@ -654,7 +654,7 @@ class Outline( object ):
         :return: The border index. FT_STROKER_BORDER_RIGHT for empty or invalid
                  outlines.
         '''
-        return FT_Outline_GetInsideBorder( self._FT_Outline )
+        return FT_Outline_GetOutsideBorder( self._FT_Outline )
 
     def get_bbox(self):
         '''

--- a/freetype/__init__.py
+++ b/freetype/__init__.py
@@ -644,7 +644,7 @@ class Outline( object ):
         :return: The border index. FT_STROKER_BORDER_RIGHT for empty or invalid
                  outlines.
         '''
-        return FT_Outline_GetInsideBorder( self._FT_Outline )
+        return FT_Outline_GetInsideBorder( byref(self._FT_Outline) )
 
     def get_outside_border( self ):
         '''
@@ -654,7 +654,7 @@ class Outline( object ):
         :return: The border index. FT_STROKER_BORDER_RIGHT for empty or invalid
                  outlines.
         '''
-        return FT_Outline_GetOutsideBorder( self._FT_Outline )
+        return FT_Outline_GetOutsideBorder( byref(self._FT_Outline) )
 
     def get_bbox(self):
         '''
@@ -2317,7 +2317,7 @@ class Stroker( object ):
           Use the function export instead if you want to retrieve all borders
           at once.
         '''
-        FT_Stroker_ExportBorder( self._FT_Stroker, border, outline._FT_Outline )
+        FT_Stroker_ExportBorder( self._FT_Stroker, border, byref(outline._FT_Outline) )
 
 
     def get_counts( self ):
@@ -2347,7 +2347,7 @@ class Stroker( object ):
 
         :param outline: The target outline.
         '''
-        FT_Stroker_Export( self._FT_Stroker, outline._FT_Outline )
+        FT_Stroker_Export( self._FT_Stroker, byref(outline._FT_Outline) )
 
 
 # -----------------------------------------------------------------------------

--- a/freetype/__init__.py
+++ b/freetype/__init__.py
@@ -2181,7 +2181,7 @@ class Stroker( object ):
 
           This function calls 'rewind' automatically.
         '''
-        error = FT_Stroker_ParseOutline( self._FT_Stroker, outline, opened)
+        error = FT_Stroker_ParseOutline( self._FT_Stroker, byref(outline._FT_Outline), opened)
         if error: raise FT_Exception( error )
 
 

--- a/freetype/__init__.py
+++ b/freetype/__init__.py
@@ -666,7 +666,7 @@ class Outline( object ):
         bbox = FT_BBox()
         error = FT_Outline_Get_BBox(byref(self._FT_Outline), byref(bbox))
         if error: raise FT_Exception(error)
-        return bbox
+        return BBox(bbox)
 
     def get_cbox(self):
         '''


### PR DESCRIPTION
- Cannot call `FT_Outline_GetOutsideBorder()` due to typo, which is needed to use `FT_Stroker`
- Some methods pass `FT_Outline` without wrapping with `ctypes.byref()`
- `Stroker.parse_outline()` currently accepts `byref(FT_Outline)` instead of `Outline`

Some of the existing Python bindings for `FT_Outline` didn't work for me. This PR is intended to address those.
