### PR TITLE
Expose binding to FT_Outline_EmboldenXY()

### DIFF
--- a/freetype/raw.py
+++ b/freetype/raw.py
@@ -269,6 +269,7 @@ FT_Outline_Copy                = _lib.FT_Outline_Copy
 FT_Outline_Decompose           = _lib.FT_Outline_Decompose
 FT_Outline_Done                = _lib.FT_Outline_Done
 FT_Outline_Embolden            = _lib.FT_Outline_Embolden
+FT_Outline_EmboldenXY          = _lib.FT_Outline_EmboldenXY
 FT_Outline_Get_Bitmap          = _lib.FT_Outline_Get_Bitmap
 FT_Outline_Get_Orientation     = _lib.FT_Outline_Get_Orientation
 FT_Outline_New                 = _lib.FT_Outline_New

--- a/freetype/raw.py
+++ b/freetype/raw.py
@@ -132,6 +132,11 @@ FT_Outline_GetInsideBorder  = _lib.FT_Outline_GetInsideBorder
 FT_Outline_GetOutsideBorder = _lib.FT_Outline_GetOutsideBorder
 FT_Outline_Get_BBox         = _lib.FT_Outline_Get_BBox
 FT_Outline_Get_CBox         = _lib.FT_Outline_Get_CBox
+try:
+    # since 2.4.10
+    FT_Outline_EmboldenXY       = _lib.FT_Outline_EmboldenXY
+except AttributeError:
+    pass
 FT_Stroker_New              = _lib.FT_Stroker_New
 FT_Stroker_Set              = _lib.FT_Stroker_Set
 FT_Stroker_Rewind           = _lib.FT_Stroker_Rewind
@@ -269,7 +274,6 @@ FT_Outline_Copy                = _lib.FT_Outline_Copy
 FT_Outline_Decompose           = _lib.FT_Outline_Decompose
 FT_Outline_Done                = _lib.FT_Outline_Done
 FT_Outline_Embolden            = _lib.FT_Outline_Embolden
-FT_Outline_EmboldenXY          = _lib.FT_Outline_EmboldenXY
 FT_Outline_Get_Bitmap          = _lib.FT_Outline_Get_Bitmap
 FT_Outline_Get_Orientation     = _lib.FT_Outline_Get_Orientation
 FT_Outline_New                 = _lib.FT_Outline_New


### PR DESCRIPTION
I noticed that [`FT_Outline_EmboldenXY()`](https://freetype.org/freetype2/docs/reference/ft2-outline_processing.html#ft_outline_emboldenxy) looks missing in `raw.py`, which is an enhanced variant to `FT_Outline_Embolden()`.

Adding a Pythonic binding should be trivial, but I'm not sure it's worth it.