### PR TITLE
Add pyinstaller hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,3 +103,18 @@ jobs:
       env:
         TWINE_USERNAME: ${{ secrets.pypi_username }}
         TWINE_PASSWORD: ${{ secrets.pypi_password }}
+
+  test-pyinstaller:
+    name: Test pyinstaller hook
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.9'
+    - name: Test pyinstaller hook
+      run: |
+        pip install pytest psutil pyinstaller>=4
+        FREETYPEPY_BUNDLE_FT=yes PYTHON_ARCH=64 pip install -e .
+        pytest -v freetype/__pyinstaller

--- a/README.rst
+++ b/README.rst
@@ -134,3 +134,10 @@ Maxim Shemarev.
 
 .. image:: https://raw.githubusercontent.com/rougier/freetype-py/master/doc/_static/agg-trick.png
 
+
+Freezing apps
+=============
+
+Freetype implements a hook for PyInstaller to help simplify the freezing process
+(it e.g. ensures that the freetype DLL is included). This hook requires
+PyInstaller version 4+.

--- a/freetype/__pyinstaller/__init__.py
+++ b/freetype/__pyinstaller/__init__.py
@@ -1,0 +1,12 @@
+from os.path import dirname
+
+
+HERE = dirname(__file__)
+
+
+def get_hook_dirs():
+    return [HERE]
+
+
+def get_test_dirs():
+    return [HERE]

--- a/freetype/__pyinstaller/conftest.py
+++ b/freetype/__pyinstaller/conftest.py
@@ -1,0 +1,1 @@
+from PyInstaller.utils.conftest import *

--- a/freetype/__pyinstaller/hook-freetype.py
+++ b/freetype/__pyinstaller/hook-freetype.py
@@ -1,0 +1,4 @@
+from PyInstaller.utils.hooks import collect_dynamic_libs
+
+
+binaries = collect_dynamic_libs("freetype")

--- a/freetype/__pyinstaller/test_freetype.py
+++ b/freetype/__pyinstaller/test_freetype.py
@@ -1,0 +1,6 @@
+def test_pyi_freetype(pyi_builder):
+    pyi_builder.test_source(
+        """
+        import freetype
+        """
+    )

--- a/setup.py
+++ b/setup.py
@@ -128,4 +128,10 @@ setup(
     ],
     keywords=['freetype', 'font'],
     setup_requires=['setuptools_scm'],
+    entry_points={
+        "pyinstaller40": [
+            "hook-dirs = freetype.__pyinstaller:get_hook_dirs",
+            "tests = freetype.__pyinstaller:get_test_dirs",
+        ],
+    },
 )


### PR DESCRIPTION
This adds a pyinstaller hook to freetype which is made discoverable using an entry point. That means that if projects wish to freeze their python application using pyinstaller, pyinstaller will automatically know that it should include the freetype binary in the package.

It includes a pytest setup that is also run on CI, which ensures that freetype can be imported from a pyinstaller-frozen application. This makes sure the hook won't be broken in the future.

(Reason for this change is that we are ensuring wgpu-py and pygfx are pyinstaller compatible by default, and freetype became one of our dependencies, so I'm contributing pyinstaller support coming from that angle :)