### PR TITLE
Add missing build-backend to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,3 @@
 [build-system]
 requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4", "certifi", "cmake"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Add missing `build-backend` declaration to `pyproject.toml`. The existence of `requires` key without a specific backend triggers an error in Gentoo packaging, as it indicates an incomplete port to PEP 517.