### PR TITLE
Remove redundant wheel dep from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4", "certifi", "cmake"]
+requires = ["setuptools>=42", "setuptools_scm[toml]>=3.4", "certifi", "cmake"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Remove the redundant `wheel` dependency, as it is added by the backend automatically.  Listing it explicitly in the documentation was a historical mistake and has been fixed since, see: https://github.com/pypa/setuptools/commit/f7d30a9529378cf69054b5176249e5457aaf640a