### PR TITLE
don't depend on cmake via pip

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4", "certifi", "cmake"]
+requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4", "certifi"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
should just rely on a system copy of cmake. fixes build on termux.

typo in the commit message oops