### PR TITLE
freetype.Face.__del__: check first if FT_Face_Done has been set to None (#169)

### DIFF
--- a/freetype/__init__.py
+++ b/freetype/__init__.py
@@ -1227,7 +1227,9 @@ class Face( object ):
         '''
         Discard  face object, as well as all of its child slots and sizes.
         '''
-        if self._FT_Face is not None:
+        # We check FT_Done_Face because by the time we're called it
+        # may already be gone (see #44 and discussion in #169)
+        if FT_Done_Face is not None and self._FT_Face is not None:
             FT_Done_Face( self._FT_Face )
 
 


### PR DESCRIPTION
When we're called during the interpreter shutdown, the functions we need may already be set to None.  So check for that before trying to call them which fixes the "'NoneType' object is not callable" errors described in issues #44 and #169.