### PR TITLE
use custom PEP517 build backend to require cmake conditionally

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
         platforms: all
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.12.3
+      uses: pypa/cibuildwheel@v2.16.5
       env:
         CIBW_BUILD: ${{ matrix.cibw_build }}
         CIBW_ARCHS: "auto64"

--- a/_custom_build/backend.py
+++ b/_custom_build/backend.py
@@ -23,3 +23,8 @@ def get_requires_for_build_wheel(config_settings=None):
         build_wheel_deps += ["certifi", "cmake"]
 
     return build_wheel_deps
+
+
+def get_requires_for_build_editable(config_settings=None):
+    # ensure pip install -e . uses same build deps as regular pip install/wheel
+    return get_requires_for_build_wheel(config_settings)

--- a/_custom_build/backend.py
+++ b/_custom_build/backend.py
@@ -1,0 +1,25 @@
+"""Custom PEP 517 build backend to provide different dependencies for wheel builds.
+
+We need some extra dependencies when we build a wheel that bundles the FreeType
+shared library (triggered when FREETYPEPY_BUNDLE_FT environment variable is set),
+as opposed to a pure Python wheel (py3-none-any.whl).
+
+For more info see:
+
+https://setuptools.pypa.io/en/latest/build_meta.html#dynamic-build-dependencies-and-other-build-meta-tweaks
+
+https://github.com/rougier/freetype-py/issues/183
+"""
+
+import os
+from setuptools import build_meta as _orig
+from setuptools.build_meta import *
+
+
+def get_requires_for_build_wheel(config_settings=None):
+    build_wheel_deps = _orig.get_requires_for_build_wheel(config_settings)
+
+    if os.environ.get("FREETYPEPY_BUNDLE_FT"):
+        build_wheel_deps += ["certifi", "cmake"]
+
+    return build_wheel_deps

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4", "certifi", "cmake"]
-build-backend = "setuptools.build_meta"
+requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
+# https://setuptools.pypa.io/en/latest/build_meta.html#dynamic-build-dependencies-and-other-build-meta-tweaks
+build-backend = "backend"
+backend-path = ["_custom_build"]


### PR DESCRIPTION
Fixes https://github.com/rougier/freetype-py/issues/183

`pip install --no-binary freetype-py freetype-py` will no longer attempt to download and install cmake in pip's temporary build environment, unless FREETYPEPY_BUNDLE_FT environment variable was set in order to compile the bundled FreeType shared library.

This makes the installation of a pure Python freetype-py (using system-wide FreeType library) quicker and doesn't require one to force --no-build-isolation just to prevent cmake from being installed unnecessarily.