### PR TITLE
[ci] fix test-pyinstaller broken after #180 was merged

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,10 @@ jobs:
       with:
         python-version: '3.9'
     - name: Test pyinstaller hook
+      env:
+        FREETYPEPY_BUNDLE_FT: yes
+        PYTHON_ARCH: 64
       run: |
         pip install pytest psutil pyinstaller>=4
-        FREETYPEPY_BUNDLE_FT=yes PYTHON_ARCH=64 pip install .
-        pytest -v freetype/__pyinstaller/tests
+        pip install .
+        pytest -v --pyargs freetype.__pyinstaller.tests


### PR DESCRIPTION
we need to export FREETYPEPY_BUNDLE_FT to ensure the correct build deps (e.g. cmake) are installed. Also run pytest --pyargs to ensure that the installed freetype is tested, not the one found in the current directory.