### PR TITLE
Fix a few typo

### DIFF
--- a/freetype/ft_structs.py
+++ b/freetype/ft_structs.py
@@ -244,7 +244,7 @@ class FT_Data(Structure):
     length: The length of the data in bytes.
     '''
     _fields_ = [('pointer', POINTER(FT_Byte)),
-                ('y',       FT_Int)]
+                ('length',  FT_Int)]
 
 
 

--- a/freetype/raw.py
+++ b/freetype/raw.py
@@ -241,7 +241,7 @@ try:
     FT_Get_Color_Glyph_Layer.restype   = FT_Bool
     FT_Get_Color_Glyph_Layer.argtypes  = [FT_Face, FT_UInt, POINTER(FT_UInt), POINTER(FT_UInt), POINTER(FT_LayerIterator)]
     FT_Get_Color_Glyph_Paint           = _lib.FT_Get_Color_Glyph_Paint # 2.13
-    FT_Get_Color_Glyph_Paint.restrype  = FT_Bool
+    FT_Get_Color_Glyph_Paint.restype   = FT_Bool
     FT_Get_Color_Glyph_Paint.argtypes  = [FT_Face, FT_UInt,
                                           FT_UInt, # FT_Color_Root_Transform enums
                                           POINTER(FT_OpaquePaint)]


### PR DESCRIPTION
The "length" field seems to have a wrong name and type.

On my linux with freetype2 installed provides this struct like this:

```c
typedef struct  FT_Data_
{
  const FT_Byte*  pointer;
  FT_UInt         length;

} FT_Data;
```

I can confirm the name `y` is wrong, but I'm not sure why use `FT_Int` in ft_structs.py.

I searched in this project and found `FT_Data` as a struct interface merely.