### PR TITLE
Fix the behavior of get_kerning to match FreeType's behavior

### DIFF
--- a/examples/hello-vf.py
+++ b/examples/hello-vf.py
@@ -27,7 +27,7 @@ if __name__ == '__main__':
         height = max(height,
                      bitmap.rows + max(0,-(slot.bitmap_top-bitmap.rows)))
         baseline = max(baseline, max(0,-(slot.bitmap_top-bitmap.rows)))
-        kerning = face.get_kerning(previous, c)
+        kerning = face.get_kerning(face.get_char_index(previous), face.get_char_index(c))
         width += (slot.advance.x >> 6) + (kerning.x >> 6)
         previous = c
 
@@ -48,7 +48,7 @@ if __name__ == '__main__':
             left = slot.bitmap_left
             w,h = bitmap.width, bitmap.rows
             y = (height - baseline - top) - (i * 48)
-            kerning = face.get_kerning(previous, c)
+            kerning = face.get_kerning(face.get_char_index(previous), face.get_char_index(c))
             x += (kerning.x >> 6)
             Z[y:y+h,x+left:x+left+w] += numpy.array(bitmap.buffer, dtype='ubyte').reshape(h,w)
             x += (slot.advance.x >> 6)

--- a/examples/hello-world-cairo.py
+++ b/examples/hello-world-cairo.py
@@ -30,7 +30,7 @@ if __name__ == '__main__':
         height = max(height,
                      bitmap.rows + max(0,-(slot.bitmap_top-bitmap.rows)))
         baseline = max(baseline, max(0,-(slot.bitmap_top-bitmap.rows)))
-        kerning = face.get_kerning(previous, c)
+        kerning = face.get_kerning(face.get_char_index(previous), face.get_char_index(c))
         width += (slot.advance.x >> 6) + (kerning.x >> 6)
         previous = c
 
@@ -47,7 +47,7 @@ if __name__ == '__main__':
         left = slot.bitmap_left
         w,h = bitmap.width, bitmap.rows
         y = height-baseline-top
-        kerning = face.get_kerning(previous, c)
+        kerning = face.get_kerning(face.get_char_index(previous), face.get_char_index(c))
         x += (kerning.x >> 6)
         # cairo does not like zero-width bitmap from the space character!
         if (bitmap.width > 0):

--- a/examples/hello-world.py
+++ b/examples/hello-world.py
@@ -28,7 +28,7 @@ if __name__ == '__main__':
         bitmap = slot.bitmap
         top = max(top, slot.bitmap_top)
         bot = min(bot, slot.bitmap_top - bitmap.rows)
-        kerning = face.get_kerning(previous, c)
+        kerning = face.get_kerning(face.get_char_index(previous), face.get_char_index(c))
         width += (slot.advance.x >> 6) + (kerning.x >> 6)
         previous = c
 
@@ -43,7 +43,7 @@ if __name__ == '__main__':
         bitmap = slot.bitmap
         w,h = bitmap.width, bitmap.rows
         y = top - slot.bitmap_top
-        kerning = face.get_kerning(previous, c)
+        kerning = face.get_kerning(face.get_char_index(previous), face.get_char_index(c))
         x += (kerning.x >> 6)
         Z[y:y+h,x+left:x+left+w] += numpy.array(bitmap.buffer, dtype='ubyte').reshape(h,w)
         x += (slot.advance.x >> 6)

--- a/examples/texture_font.py
+++ b/examples/texture_font.py
@@ -359,10 +359,10 @@ class TextureFont:
             for g in self.glyphs.values():
                 # 64 * 64 because of 26.6 encoding AND the transform matrix used
                 # in texture_font_load_face (hres = 64)
-                kerning = face.get_kerning(g.charcode, charcode, mode=FT_KERNING_UNFITTED)
+                kerning = face.get_kerning(face.get_char_index(g.charcode), face.get_char_index(charcode), mode=FT_KERNING_UNFITTED)
                 if kerning.x != 0:
                     glyph.kerning[g.charcode] = kerning.x/(64.0*64.0)
-                kerning = face.get_kerning(charcode, g.charcode, mode=FT_KERNING_UNFITTED)
+                kerning = face.get_kerning(face.get_char_index(charcode), face.get_char_index(g.charcode), mode=FT_KERNING_UNFITTED)
                 if kerning.x != 0:
                     g.kerning[charcode] = kerning.x/(64.0*64.0)
 

--- a/examples/wordle-cairo.py
+++ b/examples/wordle-cairo.py
@@ -67,7 +67,7 @@ def make_label(text, filename, size=12, angle=0):
     ymin, ymax = 0, 0
     for c in text:
         face.load_char(c, flags)
-        kerning = face.get_kerning(previous, c)
+        kerning = face.get_kerning(face.get_char_index(previous), face.get_char_index(c))
         previous = c
         bitmap = face.glyph.bitmap
         pitch  = face.glyph.bitmap.pitch
@@ -91,7 +91,7 @@ def make_label(text, filename, size=12, angle=0):
     ctx = Context(L)
     for c in text:
         face.load_char(c, flags)
-        kerning = face.get_kerning(previous, c)
+        kerning = face.get_kerning(face.get_char_index(previous), face.get_char_index(c))
         previous = c
         bitmap = face.glyph.bitmap
         pitch  = face.glyph.bitmap.pitch

--- a/examples/wordle.py
+++ b/examples/wordle.py
@@ -40,7 +40,7 @@ def make_label(text, filename, size=12, angle=0):
     ymin, ymax = 0, 0
     for c in text:
         face.load_char(c, flags)
-        kerning = face.get_kerning(previous, c)
+        kerning = face.get_kerning(face.get_char_index(previous), face.get_char_index(c))
         previous = c
         bitmap = face.glyph.bitmap
         pitch  = face.glyph.bitmap.pitch
@@ -63,7 +63,7 @@ def make_label(text, filename, size=12, angle=0):
     pen.x, pen.y = 0, 0
     for c in text:
         face.load_char(c, flags)
-        kerning = face.get_kerning(previous, c)
+        kerning = face.get_kerning(face.get_char_index(previous), face.get_char_index(c))
         previous = c
         bitmap = face.glyph.bitmap
         pitch  = face.glyph.bitmap.pitch

--- a/freetype/__init__.py
+++ b/freetype/__init__.py
@@ -1591,11 +1591,9 @@ class Face( object ):
           of the scope of this API function -- they can be implemented through
           format-specific interfaces.
         '''
-        left_glyph = self.get_char_index( left )
-        right_glyph = self.get_char_index( right )
         kerning = FT_Vector(0,0)
         error = FT_Get_Kerning( self._FT_Face,
-                                left_glyph, right_glyph, mode, byref(kerning) )
+                                left, right, mode, byref(kerning) )
         if error: raise FT_Exception( error )
         return kerning
 


### PR DESCRIPTION
This pull request fixes #202 by changing the behavior of `Face.get_kerning` to match the one of FreeType (this is done by removing the calls to `get_char_index`) and also updates the examples accordingly.

The documentation has been left untouched.
