### PR TITLE
Fetch Freetype source tarballs from a new host

### DIFF
--- a/setup-build-freetype.py
+++ b/setup-build-freetype.py
@@ -25,10 +25,10 @@ import platform
 # Needed for the GitHub Actions macOS CI runner, which appears to come without CAs.
 import certifi
 
-FREETYPE_HOST = "https://mirrors.sarata.com/non-gnu/freetype/"
-FREETYPE_TARBALL = "freetype-2.13.2.tar.xz"
+FREETYPE_HOST = "https://gitlab.freedesktop.org/freetype/freetype/-/archive/VER-2-13-2/"
+FREETYPE_TARBALL = "freetype-VER-2-13-2.tar.bz2"
 FREETYPE_URL = FREETYPE_HOST + FREETYPE_TARBALL
-FREETYPE_SHA256 = "12991c4e55c506dd7f9b765933e62fd2be2e06d421505d7950a132e4f1bb484d"
+FREETYPE_SHA256 = "175f39fd796410d136451ce9637f26d359b44258c8a2005682bacb326db80478"
 HARFBUZZ_HOST = "https://github.com/harfbuzz/harfbuzz/releases/download/8.3.0/"
 HARFBUZZ_TARBALL = "harfbuzz-8.3.0.tar.xz"
 HARFBUZZ_URL = HARFBUZZ_HOST + HARFBUZZ_TARBALL
@@ -43,6 +43,7 @@ build_dir_ft = path.join(build_dir, FREETYPE_TARBALL.split(".tar")[0], "build")
 build_dir_hb = path.join(build_dir, HARFBUZZ_TARBALL.split(".tar")[0], "build")
 
 CMAKE_GLOBAL_SWITCHES = (
+    "-DCMAKE_POLICY_VERSION_MINIMUM=3.5 " # FT==2.13.2 hack, remove after updating
     "-DCMAKE_COLOR_MAKEFILE=false "
     '-DCMAKE_PREFIX_PATH="{}" '
     '-DCMAKE_INSTALL_PREFIX="{}" '
@@ -146,7 +147,7 @@ def ensure_downloaded(url, sha256_sum):
             hasher.update(tb.read())
         assert hasher.hexdigest() == sha256_sum
 
-        with tarfile.open(tarball, "r:xz") as tb:
+        with tarfile.open(tarball, "r:*") as tb:
             tb.extractall(build_dir)
 
 

--- a/setup-build-freetype.py
+++ b/setup-build-freetype.py
@@ -25,10 +25,10 @@ import platform
 # Needed for the GitHub Actions macOS CI runner, which appears to come without CAs.
 import certifi
 
-FREETYPE_HOST = "https://gitlab.freedesktop.org/freetype/freetype/-/archive/VER-2-13-2/"
-FREETYPE_TARBALL = "freetype-VER-2-13-2.tar.bz2"
+FREETYPE_HOST = "https://download.savannah.gnu.org/releases/freetype/"
+FREETYPE_TARBALL = "freetype-2.13.2.tar.xz"
 FREETYPE_URL = FREETYPE_HOST + FREETYPE_TARBALL
-FREETYPE_SHA256 = "175f39fd796410d136451ce9637f26d359b44258c8a2005682bacb326db80478"
+FREETYPE_SHA256 = "12991c4e55c506dd7f9b765933e62fd2be2e06d421505d7950a132e4f1bb484d"
 HARFBUZZ_HOST = "https://github.com/harfbuzz/harfbuzz/releases/download/8.3.0/"
 HARFBUZZ_TARBALL = "harfbuzz-8.3.0.tar.xz"
 HARFBUZZ_URL = HARFBUZZ_HOST + HARFBUZZ_TARBALL

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -31,7 +31,7 @@ def test_bundle_version():
         import re
         p = os.path.join(test_folder, "..", "setup-build-freetype.py")
         with open(p) as f:
-            m = re.findall(r"freetype-(\d+)\.(\d+)\.?(\d+)?\.tar", f.read())
+            m = re.findall(r"freetype-(?:VER-)?(\d+)\D(\d+)\D?(\d+)?\.tar", f.read())
         version = m[0]
         if not version[2]:
             version = (int(version[0]), int(version[1]), 0)


### PR DESCRIPTION
The old host is still unavailable. This is needed to fix build scripts and CI. Resolves #200

GitLab is picked over GitHub because of the archive format, GitHub only has zips.

`tarfile.open` call modified to use universal compression since there's no `.tar.xz` file available.

Test rexgex updated to understand the new source archive filename.

FreeType 2.13.2 accidentally pinned its CMake version to 3.0 which is no longer supported by CMake. `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` is added as a workaround and must be removed after updating FreeType.