### PR TITLE
Delete setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,0 @@
-[bdist_wheel]
-universal = 0
-
-[sdist]
-formats = zip


### PR DESCRIPTION
This config file contains only outdated options.

Universal wheels are not possible since Python 2 support was dropped.

Forcing sdists to be zipped goes against modern publishing guidelines. Removing this option fixes #166